### PR TITLE
Remove bold markdown from buttons: teams.md

### DIFF
--- a/content/en/imt/servicebureau/teams.md
+++ b/content/en/imt/servicebureau/teams.md
@@ -37,7 +37,7 @@ To work with to Splunk's Team UI click on the hamburger icon top left and select
 
 When the **Team** UI is selected you will be presented with the list of current Teams.
 
-To add a new **Team** click on the {{% button style="blue" %}}**Create New Team**{{% /button %}} button. This will present you with the **Create New Team** dialog.
+To add a new **Team** click on the {{% button style="blue" %}}Create New Team{{% /button %}} button. This will present you with the **Create New Team** dialog.
 
 ![Add Team](../../images/create-new-team.png)
 
@@ -47,7 +47,7 @@ Create your own team by naming it `[YOUR-INITIALS]-Team and` add yourself by sea
 
 You can remove selected users by pressing  **Remove** or the small **x**.
 
-Make sure you have your group created with your initials and with yourself added as a member, then click {{% button style="blue" %}}**Done**{{% /button %}}
+Make sure you have your group created with your initials and with yourself added as a member, then click {{% button style="blue" %}}Done{{% /button %}}
 
 This will bring you back to the **Teams** list that will now show your Team and the one's created by others.
 
@@ -77,7 +77,7 @@ The **Email all team members** option means all members of this Team will receiv
 
 ### 3.1 Adding recipients
 
-You can add other recipients, by clicking {{% button style="blue" %}}**Add Recipient**{{% /button %}}. These recipients do not need to be Observability Cloud users.
+You can add other recipients, by clicking {{% button style="blue" %}}Add Recipient{{% /button %}}. These recipients do not need to be Observability Cloud users.
 
 However if you click on the link **Configure separate notification tiers for different severity alerts** you can configure every alert level independently.
 


### PR DESCRIPTION
Remove the bold "**" markdown within the button labels. "<strong>" markup is displaying on the front end.

- Style change

## How Has This Been Tested?

- [x] Locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas _(n/a)_
- [ ] I have made corresponding changes to the documentation _(n/a)_
- [x] My changes generate no new warnings
- [ ] Markdown Lint passes locally with my changes _(unable to write to my Gems directory in order to use mdl - any tips for workaround appreciated)_
- [ ] Any dependent changes have been merged and published in downstream modules _(n/a)_
