### PR TITLE
Adding the option to specify non-standard SSH port

### DIFF
--- a/content/en/imt/initial-setup.md
+++ b/content/en/imt/initial-setup.md
@@ -40,6 +40,8 @@ Most attendees will be able to connect to the workshop by using SSH from their M
 
 To use SSH, open a terminal on your system and type `ssh ubuntu@x.x.x.x` (replacing x.x.x.x with the IP address found in Step #1).
 
+If using a non-standard SSH port (not 22), you can specify the port number by adding `-p xxxx` to the command (where xxxx is the port number): `ssh ubuntu@x.x.x.x -p xxxx`
+
 ![ssh login](../images/ssh-1.png)
 
 When prompted **`Are you sure you want to continue connecting (yes/no/[fingerprint])?`** please type **`yes`**.

--- a/multipass/main.tf
+++ b/multipass/main.tf
@@ -67,6 +67,11 @@ variable "instance_password" {
   default = ""
 }
 
+variable "ssh_port" {
+  type    = number
+  default = 22
+}
+
 resource "random_string" "hostname" {
   length  = 4
   lower   = true
@@ -88,6 +93,7 @@ locals {
     instance_name     = "${random_string.hostname.result}"
     wsversion         = var.wsversion
     instance_password = var.instance_password
+    ssh_port          = var.ssh_port
   }
 }
 

--- a/workshop/aws/ec2/main.tf
+++ b/workshop/aws/ec2/main.tf
@@ -58,11 +58,12 @@ resource "aws_security_group" "o11y-ws-sg" {
   vpc_id = aws_vpc.o11y-ws-vpc.id
 
   ingress {
-    from_port   = 22
-    to_port     = 22
+    from_port   = var.ssh_port
+    to_port     = var.ssh_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   ingress {
     from_port   = 81
     to_port     = 81
@@ -188,6 +189,7 @@ locals {
     otel_demo         = var.otel_demo
     wsversion         = var.wsversion
     instance_password = random_string.password.result
+    ssh_port          = var.ssh_port
   }
 }
 

--- a/workshop/aws/ec2/templates/userdata.yaml
+++ b/workshop/aws/ec2/templates/userdata.yaml
@@ -229,3 +229,9 @@ runcmd:
 %{ if otel_demo == true ~}
   - su ubuntu -c 'bash /tmp/otel-demo-setup.sh'
 %{ endif ~}
+
+%{ if ssh_port != 22 ~}
+  # Change default SSH port
+  - sed -i 's/#Port 22/Port ${ssh_port}/' /etc/ssh/sshd_config
+  - sudo service sshd restart
+%{ endif ~}

--- a/workshop/aws/ec2/terraform.tfvars.template
+++ b/workshop/aws/ec2/terraform.tfvars.template
@@ -16,6 +16,7 @@ splunk_hec_token = ""
 splunk_presetup = false
 splunk_jdk = false
 otel_demo = false
+ssh_port = 65000
 
 # Advanced
 wsversion = "4.97"

--- a/workshop/aws/ec2/terraform.tfvars.template
+++ b/workshop/aws/ec2/terraform.tfvars.template
@@ -16,7 +16,7 @@ splunk_hec_token = ""
 splunk_presetup = false
 splunk_jdk = false
 otel_demo = false
-ssh_port = 65000
+ssh_port = 22
 
 # Advanced
 wsversion = "4.97"

--- a/workshop/aws/ec2/variables.tf
+++ b/workshop/aws/ec2/variables.tf
@@ -99,3 +99,8 @@ variable "aws_instance_type" {
 variable "instance_disk_aws" {
   default = "40"
 }
+
+variable "ssh_port" {
+  type = number
+  default = 22
+}

--- a/workshop/aws/ec2/variables.tf
+++ b/workshop/aws/ec2/variables.tf
@@ -101,6 +101,6 @@ variable "instance_disk_aws" {
 }
 
 variable "ssh_port" {
-  type = number
+  type    = number
   default = 22
 }


### PR DESCRIPTION
During workshops, some prospects and customers will have trouble using SSH on the default port (22), depending on their network security configurations, to access our EC2s. While accessing their instances via browser is an option, this is often slow, unreliable, and causes issues with formatting when copy/pasting commands.

The suggested changes add the option to specify a nonstandard port for SSH (ex: 65000). The default remains port 22, but gives whoever is provisioning the workshop the option to change this depending on the prospect/customer's environment.