### PR TITLE
added tagging workshop option to EC2 instance provisioning

### DIFF
--- a/workshop/aws/ec2/main.tf
+++ b/workshop/aws/ec2/main.tf
@@ -174,6 +174,7 @@ locals {
     presetup          = var.splunk_presetup
     diab              = var.splunk_diab
     otel_demo         = var.otel_demo
+    tagging_workshop  = var.tagging_workshop
     wsversion         = var.wsversion
     instance_password = random_string.password.result
     pub_key           = var.pub_key
@@ -222,6 +223,11 @@ resource "aws_instance" "observability-instance" {
       # if otel_demo=true, tokens and realm cannot be empty. also presetup cannot also be true.
       condition     = var.otel_demo ? try(var.splunk_access_token, "") != "" && try(var.splunk_realm, "") != "" && try(var.splunk_rum_token, "") != "" && try(var.splunk_presetup, "") == false : true
       error_message = "When requesting an otel_demo, splunk_realm, splunk_access_token and splunk_rum_token are required and cannot be null/empty. splunk_presetup variable must also be set to false. "
+    }
+    precondition {
+      # if tagging_workshop=true, tokens and realm cannot be empty. also presetup cannot also be true.
+      condition     = var.tagging_workshop ? try(var.splunk_access_token, "") != "" && try(var.splunk_realm, "") != "" && try(var.splunk_presetup, "") == false : true
+      error_message = "When requesting an tagging_workshop, splunk_realm and splunk_access_token are required and cannot be null/empty. splunk_presetup variable must also be set to false. "
     }
     precondition {
       # access_token and realm cannot be empty.

--- a/workshop/aws/ec2/templates/userdata.yaml
+++ b/workshop/aws/ec2/templates/userdata.yaml
@@ -203,6 +203,31 @@ write_files:
         echo ${instance_name} > /home/splunk/.helmok
       fi
 
+  - path: /tmp/tagging-workshop-setup.sh
+    permissions: '0755'
+    content: |
+      export REALM=${realm}
+      export ACCESS_TOKEN=${access_token}
+      export API_TOKEN=${api_token}
+      export INSTANCE="${instance_name}"
+      if [ ! -f /home/splunk/.helmok ]; then
+        helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+        helm repo update
+        helm install splunk-otel-collector \
+        --set="splunkObservability.realm=${realm}" \
+        --set="splunkObservability.accessToken=${access_token}" \
+        --set="clusterName=${instance_name}-k3s-cluster" \
+        --set="environment=tagging-workshop-${instance_name}" \
+        splunk-otel-collector-chart/splunk-otel-collector -f -
+
+        cd /home/splunk/workshop/tagging/
+        ./2-deploy-creditcheckservice.sh
+        ./3-deploy-creditprocessorservice.sh
+        ./4-deploy-load-generator.sh
+      
+        echo ${instance_name} > /home/splunk/.helmok
+      fi
+
 runcmd:
   - chsh -s $(which zsh) splunk
   - su splunk -c 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"'
@@ -264,3 +289,9 @@ runcmd:
 %{ if otel_demo == true ~}
   - su splunk -c 'bash /tmp/otel-demo-setup.sh'
 %{ endif ~}
+  
+%{ if tagging_workshop == true ~}
+  - su splunk -c 'bash /tmp/tagging-workshop-setup.sh'
+%{ endif ~}
+
+

--- a/workshop/aws/ec2/terraform.tfvars.template
+++ b/workshop/aws/ec2/terraform.tfvars.template
@@ -17,6 +17,7 @@ splunk_hec_token = ""
 splunk_presetup = false
 otel_demo = false
 splunk_diab = false
+tagging_workshop = false
 pub_key = ""
 
 # Advanced

--- a/workshop/aws/ec2/variables.tf
+++ b/workshop/aws/ec2/variables.tf
@@ -90,6 +90,12 @@ variable "splunk_diab" {
   default     = false
 }
 
+variable "tagging_workshop" {
+  description = "Spin up the Tagging Workshop application? (true/false)"
+  type        = bool
+  default     = false
+}
+
 variable "wsversion" {
   description = "Workshop version"
   type        = string


### PR DESCRIPTION
Hi @rcastley, please review the proposed changes to add an option to automatically deploy the OpenTelemetry collector and sample application used by the tagging workshop when this option is specified in the terraform.tfvars file. 