### PR TITLE
updated dockerfile for tagging workshop to ignore pip warnings

### DIFF
--- a/workshop/tagging/creditcheckservice-with-tags/Dockerfile
+++ b/workshop/tagging/creditcheckservice-with-tags/Dockerfile
@@ -8,6 +8,8 @@ COPY requirements.txt .
 
 RUN apt update && apt install gcc -y
 
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/workshop/tagging/creditcheckservice/Dockerfile
+++ b/workshop/tagging/creditcheckservice/Dockerfile
@@ -8,6 +8,8 @@ COPY requirements.txt .
 
 RUN apt update && apt install gcc -y
 
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/workshop/tagging/creditprocessorservice/Dockerfile
+++ b/workshop/tagging/creditprocessorservice/Dockerfile
@@ -7,6 +7,8 @@ COPY requirements.txt .
 
 RUN apt update && apt install gcc -y
 
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/workshop/tagging/loadgenerator/Dockerfile
+++ b/workshop/tagging/loadgenerator/Dockerfile
@@ -19,6 +19,9 @@ FROM base as builder
 COPY requirements.txt .
 
 RUN apt-get update && apt-get install --yes --no-install-recommends build-essential linux-headers-generic
+
+ENV PIP_ROOT_USER_ACTION=ignore
+
 RUN pip install --prefix="/install" -r requirements.txt
 
 FROM base


### PR DESCRIPTION
An error was occurring when building docker images related to running pip as root.  I followed the guidance [here](https://stackoverflow.com/questions/68673221/warning-running-pip-as-the-root-user/72551258#72551258) to resolve the issue by adding the following environment variable to the Dockerfile: 

````
ENV PIP_ROOT_USER_ACTION=ignore
````