### PR TITLE
Added 1 minute sleep to allow deployment to complete

### DIFF
--- a/workshop/aws/ec2/templates/userdata.yaml
+++ b/workshop/aws/ec2/templates/userdata.yaml
@@ -147,6 +147,12 @@ write_files:
       export HEC_URL=${hec_url}
       export INSTANCE="${instance_name}"
 
+      # Deploy Online Boutique
+      sudo kubectl apply -f /home/splunk/workshop/apm/deployment.yaml
+
+      # Sleep for 1 minute to allow the services to start
+      sleep 60
+
       # Install Splunk OpenTelemetry Collector
       if [ ! -f /home/splunk/.helmok ]; then
         helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
@@ -164,9 +170,6 @@ write_files:
         --set="splunkPlatform.index=splunk4rookies-workshop" \
         splunk-otel-collector-chart/splunk-otel-collector \
         -f /home/splunk/workshop/k3s/otel-collector.yaml
-
-      # Deploy Online Boutique
-      sudo kubectl apply -f /home/splunk/workshop/apm/deployment.yaml
 
         echo ${instance_name} > /home/splunk/.helmok
       fi


### PR DESCRIPTION
# Pull Request Template

## Description

Currently, the OTel Collector fails to pick up MySQL using the OTel receiver as it fails to connect. This fix is to add a 1 minute sleep after the deployment to allow MySQL to start.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
