### PR TITLE
Support for custom ingest/api urls for DIAB

### DIFF
--- a/workshop/ansible/diab-v3.yml
+++ b/workshop/ansible/diab-v3.yml
@@ -5,12 +5,15 @@
   pre_tasks:
     - name: Set the required variables
       set_fact:
+        ingest_url: "{{ lookup('env','INGEST_URL') }}"
+        api_url: "{{ lookup('env','API_URL') }}"
         ingest_token: "{{ lookup('env','ACCESS_TOKEN') }}"
         rum_token: "{{ lookup('env','RUM_TOKEN') }}"
         realm: "{{ lookup('env','REALM') }}"
         instance: "{{ lookup('env','INSTANCE') }}"
         hec_url: "{{ lookup('env','HEC_URL') }}"
         hec_token: "{{ lookup('env','HEC_TOKEN') }}"
+        splunk_index: "{{ lookup('env','SPLUNK_INDEX') }}"
 
   tasks:
     - name: Configure Demo-in-a-Box
@@ -64,9 +67,11 @@
             type: Opaque
             stringData:
               app: {{ instance }}-store
-              env: {{ instance}}
+              env: {{ instance }}
               deployment: "deployment.environment={{ instance }}"
               access_token: {{ ingest_token }}
+              ingest_url: {{ ingest_url }}
+              api_url: {{ api_url }}
               realm: {{ realm }}
               rum_token: {{ rum_token }}
               hec_token: {{ hec_token }}
@@ -176,9 +181,19 @@
         uri:
           url: "http://localhost:8082/saveConfig"
           method: POST
-          body: "realm={{ realm }}&ingest_token={{ ingest_token }}&rum_token={{ rum_token }}&hec_url={{ hec_url}}&hec_token={{ hec_token }}&splunk_index=splunk4rookies-workshop&instance={{ instance }}"
           status_code: [ 200, 201 ]
           timeout: 30
+          body_format: form-urlencoded
+          body:
+            ingest_url: "{{ ingest_url }}"
+            api_url: "{{ api_url }}"
+            realm: "{{ realm }}"
+            ingest_token: "{{ ingest_token }}"
+            rum_token: "{{ rum_token }}"
+            hec_url: "{{ hec_url}}"
+            hec_token: "{{ hec_token }}"
+            splunk_index: "{{ splunk_index }}"
+            instance: "{{ instance }}"
         register: splunk_api
         until: splunk_api.status == 200
         retries: 10

--- a/workshop/aws/ec2/main.tf
+++ b/workshop/aws/ec2/main.tf
@@ -167,17 +167,20 @@ locals {
   template_vars = {
     access_token      = var.splunk_access_token
     api_token         = var.splunk_api_token
-    rum_token         = var.splunk_rum_token
-    realm             = var.splunk_realm
+    api_url           = var.splunk_api_url != "" ? var.splunk_api_url : "https://api.${var.splunk_realm}.signalfx.com"
+    diab              = var.splunk_diab
     hec_token         = var.splunk_hec_token
     hec_url           = var.splunk_hec_url
-    presetup          = var.splunk_presetup
-    diab              = var.splunk_diab
+    ingest_url        = var.splunk_ingest_url != "" ? var.splunk_ingest_url : "https://ingest.${var.splunk_realm}.signalfx.com"
+    instance_password = random_string.password.result
     otel_demo         = var.otel_demo
+    presetup          = var.splunk_presetup
+    pub_key           = var.pub_key
+    realm             = var.splunk_realm
+    rum_token         = var.splunk_rum_token
+    splunk_index      = var.splunk_index
     tagging_workshop  = var.tagging_workshop
     wsversion         = var.wsversion
-    instance_password = random_string.password.result
-    pub_key           = var.pub_key
   }
 }
 

--- a/workshop/aws/ec2/templates/userdata.yaml
+++ b/workshop/aws/ec2/templates/userdata.yaml
@@ -81,13 +81,15 @@ write_files:
   - path: /etc/skel/.profile
     append: true
     content: |
-
+      export INGEST_URL=${ingest_url}
+      export API_URL=${api_url}
       export REALM=${realm}
       export ACCESS_TOKEN=${access_token}
       export API_TOKEN=${api_token}
       export RUM_TOKEN=${rum_token}
       export HEC_TOKEN=${hec_token}
       export HEC_URL=${hec_url}
+      export SPLUNK_INDEX=${splunk_index}
 
       echo "Waiting for cloud-init status..."
       if ! /usr/bin/timeout 180 grep -q 'Cloud-init .*finished at' <(sudo tail -f /var/log/cloud-init-output.log); then
@@ -118,22 +120,28 @@ write_files:
         app: ${instance_name}-store
         env: ${instance_name}-workshop
         deployment: "deployment.environment=${instance_name}-workshop"
+        ingest_url: ${ingest_url}
+        api_url: ${api_url}
         realm: ${realm}
         access_token: ${access_token}
         api_token: ${api_token}
         rum_token: ${rum_token}
         hec_token: ${hec_token}
         hec_url: ${hec_url}
+        splunk_index: ${splunk_index}
         url: frontend-external
 
   - path: /tmp/diab-setup.sh
     permissions: '0755'
     content: |
+      export INGEST_URL=${ingest_url}
+      export API_URL=${api_url}
       export RUM_TOKEN=${rum_token}
       export REALM=${realm}
       export ACCESS_TOKEN=${access_token}
       export HEC_TOKEN=${hec_token}
       export HEC_URL=${hec_url}
+      export SPLUNK_INDEX=${splunk_index}
       export INSTANCE="${instance_name}"
       ansible-playbook /home/splunk/diab-v3.yml
 
@@ -141,12 +149,15 @@ write_files:
     permissions: '0755'
     content: |
       # Export environment variables
+      export INGEST_URL=${ingest_url}
+      export API_URL=${api_url}
       export RUM_TOKEN=${rum_token}
       export REALM=${realm}
       export ACCESS_TOKEN=${access_token}
       export API_TOKEN=${api_token}
       export HEC_TOKEN=${hec_token}
       export HEC_URL=${hec_url}
+      export SPLUNK_INDEX=${splunk_index}
       export INSTANCE="${instance_name}"
 
       # Deploy Online Boutique
@@ -160,6 +171,8 @@ write_files:
         helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
         helm repo update
         helm install splunk-otel-collector \
+        --set="splunkObservability.ingestUrl=${ingest_url}" \
+        --set="splunkObservability.apiUrl=${api_url}" \
         --set="splunkObservability.realm=${realm}" \
         --set="splunkObservability.accessToken=${access_token}" \
         --set="clusterName=${instance_name}-k3s-cluster" \
@@ -169,7 +182,7 @@ write_files:
         --set="environment=${instance_name}-workshop" \
         --set="splunkPlatform.endpoint=${hec_url}" \
         --set="splunkPlatform.token=${hec_token}" \
-        --set="splunkPlatform.index=splunk4rookies-workshop" \
+        --set="splunkPlatform.index=${splunk_index}" \
         splunk-otel-collector-chart/splunk-otel-collector \
         -f /home/splunk/workshop/k3s/otel-collector.yaml
 
@@ -179,17 +192,22 @@ write_files:
   - path: /tmp/otel-demo-setup.sh
     permissions: '0755'
     content: |
+      export INGEST_URL=${ingest_url}
+      export API_URL=${api_url}
       export RUM_TOKEN=${rum_token}
       export REALM=${realm}
       export ACCESS_TOKEN=${access_token}
       export API_TOKEN=${api_token}
       export HEC_TOKEN=${hec_token}
       export HEC_URL=${hec_url}
+      export SPLUNK_INDEX=${splunk_index}
       export INSTANCE="${instance_name}"
       if [ ! -f /home/splunk/.helmok ]; then
         helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
         helm repo update
         envsubst '$REALM' < /home/splunk/workshop/oteldemo/otel-demo-collector.yaml | helm install splunk-otel-collector \
+        --set="splunkObservability.ingestUrl=${ingest_url}" \
+        --set="splunkObservability.apiUrl=${api_url}" \
         --set="splunkObservability.realm=${realm}" \
         --set="splunkObservability.accessToken=${access_token}" \
         --set="clusterName=${instance_name}-k3s-cluster" \
@@ -199,7 +217,7 @@ write_files:
         --set="environment=${instance_name}-workshop" \
         --set="splunkPlatform.endpoint=${hec_url}" \
         --set="splunkPlatform.token=${hec_token}" \
-        --set="splunkPlatform.index=splunk4rookies-workshop" \
+        --set="splunkPlatform.index=${splunk_index}" \
         splunk-otel-collector-chart/splunk-otel-collector -f -
         helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
         helm install opentelemetry-demo open-telemetry/opentelemetry-demo --values /home/splunk/workshop/oteldemo/otel-demo.yaml
@@ -209,6 +227,8 @@ write_files:
   - path: /tmp/tagging-workshop-setup.sh
     permissions: '0755'
     content: |
+      export INGEST_URL=${ingest_url}
+      export API_URL=${api_url}
       export REALM=${realm}
       export ACCESS_TOKEN=${access_token}
       export API_TOKEN=${api_token}
@@ -217,6 +237,8 @@ write_files:
         helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
         helm repo update
         helm install splunk-otel-collector \
+        --set="splunkObservability.ingestUrl=${ingest_url}" \
+        --set="splunkObservability.apiUrl=${api_url}" \
         --set="splunkObservability.realm=${realm}" \
         --set="splunkObservability.accessToken=${access_token}" \
         --set="clusterName=${instance_name}-k3s-cluster" \

--- a/workshop/aws/ec2/variables.tf
+++ b/workshop/aws/ec2/variables.tf
@@ -60,6 +60,20 @@ variable "splunk_realm" {
   nullable    = false
 }
 
+variable "splunk_ingest_url" {
+  description = "Splunk Ingest URL for Observability data"
+  type        = string
+  nullable    = false
+  default = ""
+}
+
+variable "splunk_api_url" {
+  description = "Splunk API URL for Observabiltiy APIs"
+  type        = string
+  nullable    = false
+  default = ""
+}
+
 variable "splunk_hec_token" {
   description = "Splunk Cloud HEC Token"
   type        = string
@@ -70,6 +84,13 @@ variable "splunk_hec_url" {
   description = "Splunk Cloud HEC URL"
   type        = string
   nullable    = false
+}
+
+variable "splunk_index" {
+  description = "Splunk Enterprise/Cloud index to send logs to"
+  type        = string
+  nullable    = false
+  default     = "splunk4rookies-workshop"
 }
 
 variable "splunk_presetup" {


### PR DESCRIPTION
On aws/ec2 DIAB deployments: Adding support for Splunk Observability's Ingest and API URLs that don't conform to the default template of `https://[ingest|api].<realm>.signalfx.com`.

- This change preserves the existing defaults and therefore doesn't need anything on the existing configurations to change.
- This change is also dependent on https://github.com/splunk/o11y-field-demos/pull/53 . Once the pull request is merged, the corresponding DIAB archive needs to be updated with this PR too.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Use this setup to deploy an instance of DIAB with custom ingest urls and splunk_index.

## Checklist

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Markdown Lint passes locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
