### PR TITLE
Tagging workshop fix for collector config

### DIFF
--- a/workshop/tagging/otel/values.yaml
+++ b/workshop/tagging/otel/values.yaml
@@ -6,16 +6,6 @@ certmanager:
   enabled: true
 operator:
   enabled: true
-  instrumentation:
-    spec:
-      env:
-        - name: NODE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
-        - name: SPLUNK_METRICS_ENDPOINT
-          value: http://$(NODE_IP):9943
 
 agent:
   config:


### PR DESCRIPTION
## Description

The collector deployment in the tagging workshop was failing with the following errors: 

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
operator:
(root): Additional property instrumentation is not allowed
```

It was caused by this part of the values.yaml file:
```
  instrumentation:
    spec:
      env:
        - name: NODE_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.hostIP
        - name: SPLUNK_METRICS_ENDPOINT
          value: http://$(NODE_IP):9943
```

I tried updating it to align with the changes in the latest helm chart: 

```
splunkObservability:
  logsEnabled: false
  profilingEnabled: true
  infrastructureMonitoringEventsEnabled: true
certmanager:
  enabled: true
operator:
  enabled: true
instrumentation:
  env:
    - name: NODE_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.hostIP
    - name: SPLUNK_METRICS_ENDPOINT
      value: http://$(NODE_IP):9943
```

Which produced a different error: 

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
splunk-otel-collector:
- instrumentation.env.0: value is required
- instrumentation.env.0: Additional property valueFrom is not allowed
```

Since setting the SPLUNK_METRICS_ENDPOINT environment variable is no longer required with Java 2.x instrumentation, I just removed this portion from the values.yaml file, and everything works as expected. 

## How Has This Been Tested?

Yes, I tested both the Python and Java versions of the workshop.  Java metrics are received in o11y cloud as expected. 