### PR TITLE
updated profiling workshop from Java v11 to v21

### DIFF
--- a/workshop/profiling/doorgame/Dockerfile
+++ b/workshop/profiling/doorgame/Dockerfile
@@ -1,10 +1,10 @@
-FROM gradle:8.6.0-jdk11-jammy AS build
+FROM gradle:8.14.2-jdk21-jammy AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 #RUN gradle build --no-daemon
 RUN ./gradlew shadowJar
 
-FROM openjdk:11-jre-slim as final
+FROM eclipse-temurin:21-jre-jammy as final
 
 EXPOSE 9090
 


### PR DESCRIPTION
Updated profiling workshop from Java v11 to v21.  I tested it using an EC2 instance and it works as expected. 