### PR TITLE
enabled histogram output for the profiling workshop

### DIFF
--- a/workshop/profiling/otel/values.yaml
+++ b/workshop/profiling/otel/values.yaml
@@ -1,5 +1,8 @@
 agent:
   config:
+    exporters:
+      signalfx:
+        send_otlp_histograms: true
     processors:
       resource/envname:
         attributes:


### PR DESCRIPTION
Enabled histogram output for the profiling workshop, to ensure the garbage collection chart in the memory profiling page is populated as expected. 