### PR TITLE
fixed issues in the solving problems with o11y cloud workshop

### DIFF
--- a/content/en/ninja-workshops/9-solving-problems-with-o11y-cloud/2-deploy-collector.md
+++ b/content/en/ninja-workshops/9-solving-problems-with-o11y-cloud/2-deploy-collector.md
@@ -222,7 +222,7 @@ Add the debug exporter by copying and pasting the following text to the bottom o
       pipelines:
         traces:
           exporters:
-            - sapm
+            - otlphttp
             - signalfx
             - debug
 ```
@@ -237,6 +237,8 @@ certmanager:
   enabled: true
 operator:
   enabled: true
+operatorcrds:
+  install: true
 
 agent:
   config:
@@ -266,7 +268,7 @@ agent:
       pipelines:
         traces:
           exporters:
-            - sapm
+            - otlphttp
             - signalfx
             - debug
 ```
@@ -282,7 +284,7 @@ Once the file is saved, we can apply the changes with:
 ``` bash
 cd /home/splunk/workshop/tagging
 
-helm upgrade splunk-otel-collector --version {{< otel-version >}} \
+helm upgrade splunk-otel-collector  \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \
@@ -320,7 +322,7 @@ We can see that the debug exporter was added to the traces pipeline, as desired:
 ``` yaml
   traces:
     exporters:
-    - sapm
+    - otlphttp
     - signalfx
     - debug
 ```

--- a/workshop/tagging/otel/values.yaml
+++ b/workshop/tagging/otel/values.yaml
@@ -5,6 +5,8 @@ certmanager:
   enabled: true
 operator:
   enabled: true
+operatorcrds:
+  install: true
 
 agent:
   config:


### PR DESCRIPTION
# Pull Request Template

## Description

The collector install in the Solving Problems in O11y Cloud workshop was failing because the config had the operator enabled without operatorcrds.install set to true.   I also noticed that the workshop still referred to the sapm exporter, which is no longer present. 

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in a workshop EC2 instance spun up using Terraform 
