### PR TITLE
Authenticate release workflow checkout with deploy key

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
## Summary
- Adds `ssh-key: ${{ secrets.RELEASE_SSH_KEY }}` to the `actions/checkout` step in the deploy workflow so the workflow's git operations authenticate via the SSH deploy key.
- This trips the `DeployKey` bypass entry on the `Workshop` ruleset, allowing the release commit + tag to push to `main` once the "Require a pull request before merging" rule is re-enabled.
- No-op while the ruleset only contains the `deletion` rule — the current default-token push already works.

## Why
When the PR-requirement rule was active, the release workflow failed at `git push --follow-tags origin main` with `GH013: Changes must be made through a pull request`. Re-enabling that rule (so humans must PR) needs the workflow to authenticate as the bypass actor — the deploy key.

## Test plan
- [ ] Re-enable "Require a pull request before merging" on the Workshop ruleset.
- [ ] Trigger the workflow via `workflow_dispatch` and confirm the bumpversion commit + tag push to `main` succeed.
- [ ] Confirm gh-pages deploy and GitHub release still succeed.