### PR TITLE
Try shallow clone (fetch-depth: 1) in deploy workflow

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 1
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Setup Hugo


### PR DESCRIPTION
## Summary
- Switches `actions/checkout` from `fetch-depth: 0` (full history) to `fetch-depth: 1` (shallow, tip commit only).
- Expected gain: ~50s off the workflow's checkout step.
- Expected loss: Hugo's `enableGitInfo` returns nil for almost every page (only the latest commit is in history), so `.GitInfo.AuthorDate` is empty. The `content-footer.html` partial has a fallback to `.Params.Date`, but content frontmatter doesn't set `date:`, so the **"Last Modified" badge will simply not render on most pages**. No broken UI — the badge just disappears.

## Test plan
- [ ] Merge and trigger the Deploy workflow via `workflow_dispatch`.
- [ ] Confirm checkout step is meaningfully faster.
- [ ] Confirm Hugo build still succeeds (warnings about missing GitInfo are expected and fine).
- [ ] Spot-check published site: verify pages render without errors. "Last Modified" badge missing is expected.
- [ ] If anything regresses, revert by flipping back to `fetch-depth: 0`.

## Rollback
Single-line revert.