### PR TITLE
Drop redundant 'git fetch --tags origin' from release step

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -73,7 +73,6 @@ jobs:
           awk "NR==1,/Latest versions of the workshop are:/{c=3} c&&c-- " > README.new.md
           mv README.new.md README.md
 
-          git fetch --tags origin
           git add README.md
           git commit --amend -m "Releasing v${TAG}"
           git tag -a "v${TAG}" -m "Version ${TAG}"


### PR DESCRIPTION
## Summary
- Removes the `git fetch --tags origin` line from the bump-version step.
- This line back-fills all tagged historical commits when run against a shallow clone — ~84s of the ~106s the step now takes with `fetch-depth: 1`.
- The fetch was defensive against local/remote tag drift. With the deploy key bypass in place and clean tag state, it's not load-bearing — `git push --follow-tags` will be rejected by the remote if the tag already exists, which is a clean failure mode.

## Expected outcome
- Bump-version step drops from ~1m 46s back to a couple of seconds.
- Combined with the shallow checkout (~11s vs ~60s), total workflow time should drop by ~50s vs the original `fetch-depth: 0` baseline.

## Test plan
- [ ] Merge and trigger the Deploy workflow.
- [ ] Confirm bump-version step is fast (<10s).
- [ ] Confirm the release commit + tag push to `main` and `v6.68` tag both succeed.
- [ ] Confirm GitHub release is created and gh-pages updates.
- [ ] If anything regresses, revert (one-line restore).

## Rollback
Restore the single line.