### PR TITLE
Revert shallow-clone experiment in deploy workflow

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-          fetch-depth: 1
+          fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Setup Hugo
@@ -73,6 +73,7 @@ jobs:
           awk "NR==1,/Latest versions of the workshop are:/{c=3} c&&c-- " > README.new.md
           mv README.new.md README.md
 
+          git fetch --tags origin
           git add README.md
           git commit --amend -m "Releasing v${TAG}"
           git tag -a "v${TAG}" -m "Version ${TAG}"


### PR DESCRIPTION
## Summary
Reverts the two experimental PRs (#522 and #523) that tried to speed up the deploy workflow by using a shallow clone.

## Why revert
The shallow clone shifted cost rather than removing it:

| | Checkout | Bump-version | Total |
|---|---|---|---|
| Original (`fetch-depth: 0`) | ~60s | ~2s | **~2m 34s** |
| After #522 (`fetch-depth: 1`) | 11s | 1m 46s | ~3m 13s |
| After #523 (also dropped `git fetch --tags`) | 11s | 1m 25s | similar |

The remaining time after dropping `git fetch --tags` was traced to `git pull --rebase` taking ~83s to negotiate "Already up to date" against a deep-history repo on a shallow client. That's a protocol-level cost we can't avoid without removing more safety nets.

## Test plan
- [ ] Merge and trigger the next release.
- [ ] Confirm total workflow time returns to ~2m 34s baseline.