### PR TITLE
Improving and padding the workshop content in readiness for backup selector paths

### DIFF
--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/1-recording-a-test.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/1-recording-a-test.md
@@ -3,6 +3,8 @@ title: 1.1 Recording a test
 weight: 1
 ---
 
+In this step you'll capture a complete user journey through the demo Online Boutique storefront using the Chrome DevTools Recorder. The recorder watches your interactions and records each click, keystroke, and navigation as a structured step. For every element you interact with it captures **multiple selector strategies** (CSS, XPath, etc.), so the resulting test is robust against most front-end changes — if one selector breaks the next is tried in turn. You'll save the recording to a JSON file that you'll import into Splunk Synthetic Monitoring in the next step.
+
 ## Open the starting URL
 
 Open the starting URL for the workshop in Chrome. Click on the appropriate link below to open the site in a new tab.
@@ -31,7 +33,7 @@ Next, open the Developer Tools (in the new tab that was opened above) by pressin
 ![Open Recorder](../../img/open-recorder.png)
 
 {{% notice title="Note" style="info" %}}
-Site elements might change depending on viewport width. Before recording, set your browser window to the correct width for the test you want to create (Desktop, Tablet, or Mobile). Change the DevTools "dock side" to pop out as a separate window if it helps.
+Site elements might change depending on viewport width. Before recording, set your browser window to the correct width for the test you want to create (Desktop, Tablet, or Mobile). Responsive sites often hide menu items behind a hamburger icon below a breakpoint — recording a "click the cart link" on a wide window won't replay correctly if the test runs at a mobile viewport. Change the DevTools "dock side" to pop out as a separate window if it helps.
 {{% /notice %}}
 
 ## Create a new recording
@@ -66,6 +68,14 @@ Select **JSON** as the format, then click on **Save**
 ![Save JSON](../../img/save-json.png)
 
 **Congratulations!** You have successfully created a recording using the Chrome DevTools Recorder. Next, we will use this recording to create a Real Browser Test in Splunk Synthetic Monitoring.
+
+### What's actually in the JSON?
+
+Open the expandable below if you'd like to inspect the recording. A few things worth noticing:
+
+- Each interaction is an object with a `type` (`navigate`, `click`, etc.) and a list of `selectors` — that's the multi-strategy fallback we mentioned at the start. The recorder lists them in priority order; the test runner tries each until one matches.
+- The first step is a `setViewport`, which pins the window dimensions so the test always replays at the same size regardless of which location it runs from.
+- Most click steps include `assertedEvents` with a `navigation` URL and page `title`. These are the recorder's way of locking in expected outcomes — if a click *should* result in a navigation to `/cart` and it doesn't, the step fails. You'll see this surface in run results as a clear assertion failure rather than a vague timeout.
 
 ---
 

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/2-create-real-browser-test.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/2-create-real-browser-test.md
@@ -3,12 +3,18 @@ title: 1.2 Create Real Browser Test
 weight: 2
 ---
 
-In Splunk Observability Cloud, navigate to **Synthetics** and click on {{% button style="blue" %}}Add new test{{% /button %}}.
+The recording you just saved is a local file — it can't fail an alert, can't run from London at 3am, and can't tell you whether checkout was slow yesterday. Moving from a recording to a Splunk Synthetic Monitoring test is what unlocks all of that: the same user journey, now executed continuously from cloud locations you choose, with results that flow into the same Observability Cloud organisation as your metrics, logs, and traces.
 
-From the dropdown select **Browser test**.
+In Splunk Observability Cloud, navigate to **Synthetics**. The landing page surfaces the three Synthetic Monitoring check types:
+
+- **Browser tests** — the full-Chromium real-user-journey checks we're building today.
+- **Uptime tests** — lightweight port and HTTP availability checks.
+- **API tests** — multi-step HTTP transaction checks (we'll build one in Part 2).
+
+Click on {{% button style="blue" %}}Add new test{{% /button %}} and select **Browser test** from the dropdown.
 
 ![Add new test](../../img/add-new-test.png)
 
-You will then be presented with the **Browser test content** configuration page.
+You will then be presented with the **Browser test content** configuration page — this is where you'll import the JSON you exported a moment ago, configure where and how often the test runs, and name each step so on-call engineers can read run results at a glance.
 
 ![New Test](../../img/new-test.png)

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/3-import-json.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/3-import-json.md
@@ -3,18 +3,24 @@ title: 1.3 Import JSON
 weight: 3
 ---
 
-To begin configuring our test, we need to import the JSON that we exported from the Chrome DevTools Recorder. To enable the {{% button %}}**Import**{{% /button %}} button, we must first give our test a name e.g. **`<your initials>` - Online Boutique**.
+To begin configuring our test we need to import the JSON file we exported from the Chrome DevTools Recorder. Splunk Synthetic Monitoring understands the recorder's native JSON format directly, so there's no conversion step — the importer reads each recorded step and creates a corresponding synthetic-test step, preserving the selectors, viewport, and any asserted navigation events.
+
+To enable the {{% button %}}**Import**{{% /button %}} button, we must first give our test a name. Use the same convention as the recording — your initials followed by the journey, e.g. **`<your initials>` - Online Boutique**. Prefixing with initials makes it easy for trainers and teammates to find each other's work in a shared organisation.
 
 ![Import](../../img/import.png)
 
-Once the {{% button %}}**Import**{{% /button %}} button is enabled, click on it and either drop the JSON file that you exported from the Chrome DevTools Recorder or upload the file.
+Once the {{% button %}}**Import**{{% /button %}} button is enabled, click on it and either drop the JSON file that you exported from the Chrome DevTools Recorder, or browse for it.
 
 ![Import JSON](../../img/import-json.png)
 
-Once the JSON file has been uploaded, click on {{% button style="blue" %}}Continue to edit steps{{% /button %}}
+Once the JSON has been parsed, you'll see a green confirmation showing the number of steps imported. If you ever see a smaller number than you expected here, it usually means one of the recorded actions wasn't in a format the Synthetics importer recognised — re-recording that specific interaction usually resolves it.
+
+Click on {{% button style="blue" %}}Continue to edit steps{{% /button %}}.
 
 ![Import Complete](../../img/import-complete.png)
 
+The **Edit steps** view shows each imported step in order, with the action type, target selector, and any wait conditions. You can reorder, add, or remove steps from here — but we'll come back to that in a later section.
+
 ![Edit Steps](../../img/edit-steps.png)
 
-Before we make any edits to the test, let's first configure the settings, click on {{% button style="blue" %}}< Return to test{{% /button %}}
+Before we make any edits to the steps themselves, let's first configure the test's run-time settings — where it runs from, how often, and on what device. Click on {{% button style="blue" %}}< Return to test{{% /button %}}.

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/4-edit-test-settings.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/4-edit-test-settings.md
@@ -3,28 +3,61 @@ title: 1.4 Settings
 weight: 4
 ---
 
-The simple settings allow you to configure the basics of the test:
+Every setting on this page maps directly to a real-world tradeoff between coverage, cost, signal quality, and load on the system you're monitoring. Before clicking through, here's what each control actually controls and the rule of thumb for choosing a value.
 
-- **Name**: The name of the test (e.g. RWC - Online Boutique).
-- **Details**:
-  - **Locations**: The locations where the test will run from.
-  - **Device**: Emulate different devices and connection speeds. Also, the viewport will be adjusted to match the chosen device.
-  - **Frequency**: How often the test will run.
-  - **Round-robin**: If multiple locations are selected, the test will run from one location at a time, rather than all locations at once.
-  - **Active**: Set the test to active or inactive.
+## Name
 
-![Return to Test]For this workshop, we will configure the locations that we wish to monitor from. Click in the **Locations** field and you will be presented with a list of global locations (over 50 in total).
+The display name for the test — used everywhere in the UI, in alert messages, in linked dashboards, and in detector titles. Bake context into it: include the service name, the journey, and (in shared organisations) your initials. **`<your initials>` - Online Boutique** works well for this workshop.
 
-![Global Locations](../../img/global-locations.png)
+## Locations
 
-Select the following locations:
+The cloud regions Splunk runs the test from. There are over 50 to choose from, spread across all the major AWS regions. **Location choice matters more than people expect** because the metric you get back is the *measured* user experience from that location — network latency, TLS handshake time, and any geographic CDN routing are all baked in. A site that loads in 800 ms from N. Virginia might take 2.4 s from Mumbai if your CDN doesn't cache there.
+
+Best practice: pick locations that match where your real users live. If you have a US-east customer base and a separate EMEA customer base, monitor from both — and add at least one location that's *far* from any user (e.g. Melbourne for a US-only product) as an early-warning canary for global routing or DNS issues.
+
+For this workshop we'll use three locations spanning three continents:
 
 - **AWS - N. Virginia**
 - **AWS - London**
 - **AWS - Melbourne**
 
-Once complete, scroll down and click on Click on {{% button style="blue" %}}Submit{{% /button %}} to save the test.
+Click in the **Locations** field and select each from the dropdown.
 
-The test will now be scheduled to run every 5 minutes from the 3 locations that we have selected. This does take a few minutes for the schedule to be created.
+![Global Locations](../../img/global-locations.png)
 
-So whilst we wait for the test to be scheduled, click on {{% button %}}Edit test{{% /button %}} so we can go through the Advanced settings.
+## Device
+
+Emulates a specific device profile, which sets the viewport dimensions, user agent string, and a *throttled* CPU and network profile that approximates that device. The viewport stays consistent regardless of which location the test runs from.
+
+Why this matters: a fast-3G-throttled iPhone X with 4× CPU slowdown will surface real-user pain that an unthrottled desktop test would mask entirely. If your users are mostly on mobile, monitor on mobile.
+
+## Frequency
+
+How often the test runs from each location. The shorter the interval, the faster you'll catch a regression — but the more capacity you'll burn through and the more load you'll apply to the target site. Pick the lowest frequency that still gives your detectors a useful signal:
+
+| Frequency | Typical use |
+| --- | --- |
+| 1 min | Critical user journeys for high-traffic, high-revenue sites |
+| 5 min | Default for most production journeys (this workshop's setting) |
+| 10–15 min | Pre-prod, staging, lower-priority flows |
+| 30–60 min | Marketing pages, low-change static content |
+
+Remember the alert math: a 5-minute frequency means it can take **up to 5 minutes** to *first* detect a regression, and most detectors require 2–3 consecutive failures to fire — so a 5-minute test may not alert for 10–15 minutes after an incident begins.
+
+## Round-robin
+
+If you've selected multiple locations, **round-robin** changes how they're scheduled. Off (the default) means all selected locations run on every interval — three locations × every 5 minutes = 36 runs/hour. On means Splunk rotates through the locations, running one per interval — three locations × every 5 minutes = 12 runs/hour, but each individual location is now only sampled every 15 minutes.
+
+The tradeoff: round-robin slashes your run consumption and applies less load to the target, but dilutes per-location signal (so location-specific regressions are slower to surface). Leave it off for this workshop.
+
+## Active
+
+Toggles the test on or off. Leave it on. You can disable it later from the test list if you no longer want the run history accumulating.
+
+---
+
+Once you've set the name and selected the three locations, scroll down and click {{% button style="blue" %}}Submit{{% /button %}} to save the test.
+
+The test is now scheduled to run every 5 minutes from N. Virginia, London, and Melbourne. The first run usually takes a couple of minutes to dispatch — the scheduler has to allocate a browser slot in each region — so don't worry if you don't see results immediately.
+
+While we wait, click on {{% button %}}Edit test{{% /button %}} so we can take a look at the **Advanced** settings.

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/5-advanced-settings.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/5-advanced-settings.md
@@ -3,7 +3,9 @@ title: 1.5 Advanced Settings
 weight: 5
 ---
 
-Click on **Advanced**, these settings are optional and can be used to further configure the test.
+The default settings are enough for most public, unauthenticated journeys — but real production sites often need at least one of the controls under **Advanced**. We're not going to set any of them for this workshop, but it's worth knowing what each one is for so you can reach for the right tool later.
+
+Click on **Advanced** to expand the panel.
 
 {{% notice note %}}
 In the case of this workshop, we will **not** be using any of these settings as this is for informational purposes only.
@@ -11,12 +13,15 @@ In the case of this workshop, we will **not** be using any of these settings as 
 
 ![Advanced Settings](../../img/advanced-settings.png)
 
-- **Security**:
-  - **TLS/SSL validation**: When activated, this feature is used to enforce the validation of expired, invalid hostname, or untrusted issuer on SSL/TLS certificates.
-  - **Authentication**: Add credentials to authenticate with sites that require additional security protocols, for example from within a corporate network. By using [concealed global variables](https://docs.splunk.com/Observability/synthetics/test-config/global-variables.html) in the Authentication field, you create an additional layer of security for your credentials and simplify the ability to share credentials across checks.
-- **Custom Content**:
-  - **Custom headers**: Specify custom headers to send with each request. For example, you can add a header in your request to filter out requests from analytics on the back end by sending a specific header in the requests. You can also use custom headers to set cookies.
-  - **Cookies**: Set cookies in the browser before the test starts. For example, to prevent a popup modal from randomly appearing and interfering with your test, you can set cookies. Any cookies that are set will apply to the domain of the starting URL of the check. Splunk Synthetics Monitoring uses the public suffix list to determine the domain.
-  - **Host overrides**: Add host override rules to reroute requests from one host to another. For example, you can create a host override to test an existing production site against page resources loaded from a development site or a specific CDN edge node.
+## Security
 
-Next, we will edit the test steps to provide more meaningful names for each step.
+- **TLS/SSL validation** — when activated, this enforces validation of certificate expiry, hostname mismatch, and untrusted issuer chains. Turning this *off* is sometimes necessary for testing against staging environments with self-signed certificates, but you should never leave it off for a production test — it disables one of the cheapest early-warning signals you have for certificate-related outages.
+- **Authentication** — credentials sent with every request, useful for sites behind HTTP Basic auth (still common on internal tooling and pre-prod environments). Store the credentials as [concealed global variables](https://docs.splunk.com/Observability/synthetics/test-config/global-variables.html) rather than typing them inline — concealed values aren't visible to anyone reading the test config, and they can be rotated in one place without editing every test that uses them.
+
+## Custom Content
+
+- **Custom headers** — extra headers sent on every request the test makes. Common uses: an `X-Synthetics: true` (or similar) header that your backend can use to exclude synthetic traffic from analytics dashboards and from RUM aggregations; a `Cache-Control: no-cache` header to test cold-cache performance; an A/B test cookie or feature-flag override header to pin the test to a specific variant.
+- **Cookies** — set in the browser *before* the test starts. The classic use case is suppressing a one-time-only modal (cookie banner, "subscribe to our newsletter" popup) that would otherwise occlude an element the test needs to click. Cookies are scoped to the domain of the starting URL, with Splunk Synthetic Monitoring using the [public suffix list](https://publicsuffix.org/) to determine the registrable domain.
+- **Host overrides** — reroute requests from one host to another at DNS-resolution time. Two common patterns: testing a production URL against a CDN edge node you're about to promote (override `www.example.com` to a specific edge IP); or running a production-shaped test against staging-shaped backends (override `api.example.com` to `api-staging.example.com`) without rewriting every step in the journey.
+
+Next, we'll edit the test steps to give each one a meaningful name — which becomes important the moment a step starts failing and a teammate has to read the alert.

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/6-edit-steps.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/6-edit-steps.md
@@ -3,23 +3,49 @@ title: 1.6 Edit test steps
 weight: 6
 ---
 
-To edit the steps click on the {{< button >}}+ Edit steps or synthetic transactions{{< /button >}} button. From here, we are going to give meaningful names to each step.
+By default the steps that come out of the Chrome Recorder have generic names like **"Go to URL"** or **"Click on `<button>`"**. That's fine while you're authoring the test, but the moment a step fails and a colleague is staring at an alert at 3am, **"Step 3 failed: Click on `<button>`"** tells them nothing useful. **"Step 3 failed: Add to Cart"** tells them exactly where in the user journey the regression is.
+
+Step names also surface in:
+
+- The Synthetic Monitoring run results UI (per-step waterfall, screenshots).
+- Detector alert messages and notifications.
+- Linked Observability Cloud dashboards that filter on `synthetic.step`.
+
+It's worth a minute to make them readable.
+
+To edit the steps click on the {{< button >}}+ Edit steps or synthetic transactions{{< /button >}} button.
 
 ![Edit steps](../../img/edit-steps.png)
 
-For each of the four steps, we are going to give them a meaningful name.
+For each of the four steps, give it a meaningful name:
 
-- **Step 1** replace the text **Go to URL** with **HomePage - Online Boutique**
-- **Step 2** enter the text **Select Vintage Camera Lens**.
-- **Step 3** enter **Add to Cart**.
-- **Step 4** enter **Place Order**.
+- **Step 1** — replace **Go to URL** with **HomePage - Online Boutique**.
+- **Step 2** — enter **Select Vintage Camera Lens**.
+- **Step 3** — enter **Add to Cart**.
+- **Step 4** — enter **Place Order**.
 
 ![Step names](../../img/step-names.png)
 
+{{% notice title="Tip — Synthetic Transactions" style="info" %}}
+The same panel lets you group multiple steps into a **synthetic transaction** — a named subset of the journey you want to track as a single timing (e.g. "Checkout" wrapping the cart, payment, and order-confirmation steps). Transactions show up as their own row in the run waterfall and as their own metric you can chart and alert on. We won't create one here, but it's a powerful pattern for monitoring critical sub-flows independently of the total run time.
+{{% /notice %}}
+
 Click {{% button style="blue" %}}< Return to test{{% /button %}} to return to the test configuration page and click {{% button style="blue" %}}Save{{% /button %}} to save the test.
 
-You will be returned to the test dashboard where you will see test results start to appear.
+You'll be returned to the test dashboard. After a couple of minutes the first results will start to appear in the **Performance KPIs** scatterplot.
 
 ![Scatterplot](../../img/scatterplot.png)
 
-**Congratulations!** You have successfully created a Real Browser Test in Splunk Synthetic Monitoring. Next, we will look into a test result in more detail.
+## Reading the scatterplot
+
+Each dot on the scatterplot is one test run:
+
+- **X axis** is time — newest runs on the right.
+- **Y axis** is run duration in seconds — lower is faster.
+- **Colour** is location — in this workshop you'll see three series (N. Virginia, London, Melbourne).
+
+The controls along the top let you change the **time range**, the **aggregation interval** (5m, 1h, etc.), the **scale** (linear or logarithmic — log is useful when one location is much slower than the others), the **location filter**, and the **metric** you're plotting (defaults to run duration, but you can switch to any individual web vital).
+
+Watch for two patterns over time: a *step change* in duration (something changed in the site or its dependencies — usually a deploy or a CDN config), and a *spread* between locations widening (a regional issue — a CDN edge, a regional dependency, a DNS problem).
+
+**Congratulations!** You have successfully created a Real Browser Test in Splunk Synthetic Monitoring. Next, we'll click into a single run and unpack everything Synthetics captured about it.

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/7-view-test-results.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/7-view-test-results.md
@@ -3,6 +3,60 @@ title: 1.7 View test results
 weight: 7
 ---
 
-In the Scatterplot from the previous step, click on one of the dots to drill into the test run data. Preferably, select the most recent test run (farthest to the right).
+In the Scatterplot from the previous step, click on one of the dots to drill into the test run data. Preferably, select the most recent test run (farthest to the right) so the run is as close to the current site state as possible.
 
 ![Drilldown](../../img/drilldown.png)
+
+This single page captures **everything** Splunk Synthetic Monitoring recorded for that one run from that one location. It's worth understanding what each section is for — these are the views you'll spend the most time in when triaging a regression.
+
+## Result header
+
+At the top of the page you'll see the run's high-level outcome:
+
+- **Status** — Success or Failure, with the failing step called out by name if there was one (this is why the step renaming in the previous chapter pays off).
+- **Location** — the AWS region the run came from. Cross-reference with the scatterplot if you're chasing a region-specific regression.
+- **Timestamp** — when the run started, in your local timezone.
+- **Total duration** — how long the journey took end to end.
+
+## Filmstrip and video
+
+The strip of screenshots across the top is a **filmstrip** — Synthetic Monitoring captures a screenshot at regular intervals throughout the run, so you can scrub through the entire journey visually. On the right is a **video replay** of the page as the test saw it, with a standard player you can scrub through frame by frame.
+
+Filmstrip and video are by far the fastest way to answer "what did the user actually see?" — particularly useful when a step failed because of an unexpected modal, a content-shift error, or a missing element. They're often the only thing you need to share with a developer to make a bug reproducible.
+
+## Business transactions and pages
+
+Below the filmstrip you'll see two summary rows:
+
+- **Business Transactions** — any synthetic transactions you defined in the step editor (we didn't define any in this workshop, so you'll see a default "Synthetic transaction 1" entry). Each transaction shows up as its own bar with its own duration.
+- **Pages** — every distinct URL the journey visited, in order. For the Online Boutique test you'll see four: the home page, the product page for the Vintage Camera Lens, the cart, and the checkout confirmation. Click any of them to filter the waterfall below to only that page's resources.
+
+## Waterfall
+
+The waterfall is the workhorse of the results page — every individual HTTP request the page made, in order, with the timing and status of each. The filter bar lets you narrow by resource type (**All / XHR / JS / CSS / Img / Media / Font / Doc / WS / Manifest**), and each row shows:
+
+- **METHOD** — usually `GET`, but POSTs to APIs will surface here too.
+- **FILE** — the resource path. Clicking a row expands timing details (DNS, connect, TLS, request, response, content download).
+- **DOMAIN** — useful for spotting third-party tax: if `cdn.googletagmanager.com` or your A/B test SDK consistently shows up near the top of the slow list, you've found a candidate to defer or remove.
+- **SIZE** — the over-the-wire size. Watch for surprises here (a 4 MB hero image, an un-minified bundle).
+- **STATUS** — the HTTP status code. Anything red is worth investigating, but also watch for unexpected `301`/`302` chains that add latency without failing.
+
+## Web Vitals
+
+On the right of the page, Splunk reports the [Core Web Vitals](https://web.dev/articles/vitals) for this run:
+
+- **Largest Contentful Paint (LCP)** — how long until the largest visible content element (usually a hero image or main heading) finished rendering. Good: ≤ 2.5s, needs improvement: ≤ 4s, poor: > 4s.
+- **Total Blocking Time (TBT)** — total time the main thread was blocked by long tasks during page load. The lab-environment analogue of First Input Delay. Good: ≤ 200ms, poor: > 600ms.
+- **Cumulative Layout Shift (CLS)** — how much the layout shifted unexpectedly during load (think: a banner pushing the article down after you've started reading). Good: ≤ 0.1, poor: > 0.25.
+
+Because these are Google's standard web-vitals metrics, you can chart them and alert on them the same way you would in any RUM tool — and unlike RUM, the synthetic version comes from a controlled environment, so a regression in synthetic LCP is almost always a code change rather than a user-environment change.
+
+## What to do next
+
+Once you're comfortable with this view, a few useful follow-ups in real production use:
+
+- **Create detectors** on the metrics surfaced here (run duration, step duration, individual web vitals). Splunk Synthetic Monitoring's detectors live alongside your other Observability Cloud detectors and can fire to the same notification channels.
+- **Correlate with RUM**. If the site is RUM-instrumented and shows the same regression in real-user data, you have a production-impacting issue. If only synthetic regresses, it's often a third-party dependency or a code path users aren't currently hitting.
+- **Compare runs across locations** by going back to the scatterplot — if Melbourne consistently runs 8 seconds slower than London for the same journey, your CDN coverage for APAC is doing real damage you can quantify.
+
+This run is now part of your test's history forever — every metric on this page is also a time series you can chart, dashboard, and alert on.

--- a/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/_index.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/1-real-browser-test/_index.md
@@ -5,13 +5,14 @@ weight: 1
 
 ## Introduction
 
-This workshop walks you through using the [Chrome DevTools Recorder](https://developer.chrome.com/docs/devtools/recorder/) to create a synthetic transaction against a Splunk demonstration instance.
+This part of the workshop walks you through using the [**Chrome DevTools Recorder**](https://developer.chrome.com/docs/devtools/recorder/) to create a synthetic transaction against a Splunk demonstration instance. You'll export that recording as JSON and use it to create a **Splunk Synthetic Monitoring Real Browser Test** that runs from the cloud, on a schedule, from multiple global locations.
 
-The exported JSON from the Chrome DevTools Recorder will then be used to create a Splunk Synthetic Monitoring Real Browser Test.
+### What is a Real Browser Test?
 
-In addition, you will also get to learn other Splunk Synthetic Monitoring checks like [API Test](https://docs.splunk.com/Observability/synthetics/api-test/api-test.html) and [Uptime Test](https://docs.splunk.com/Observability/synthetics/uptime-test/uptime-test.html).
+A Real Browser Test (RBT) is a synthetic check where Splunk Synthetic Monitoring spins up a **full Chromium browser** in one of its global cloud locations, loads your site, and drives it through a sequence of user actions — clicks, form input, navigation — exactly as a real person would. Because it's a real browser, it executes JavaScript, runs your full third-party dependency graph, applies CSS, and captures everything a regular user's browser does. That makes RBTs ideal for monitoring user journeys end to end: login, checkout, search, dashboard load.
 
-## Pre-requisites
+The trade-off versus a simple HTTP uptime check is cost and run frequency — a real-browser run takes 10–30 seconds and consumes more capacity, so RBTs are typically scheduled every 1–5 minutes per location, where uptime checks can run every minute against many endpoints at little cost.
 
-- Google Chrome Browser installed
-- Access to Splunk Observability Cloud
+### Why start with the Chrome DevTools Recorder?
+
+You can hand-author a Synthetic test step by step in the Splunk UI, but recording the journey first is faster and less error-prone — the recorder captures multiple resilient selectors for every element you click (CSS, XPath, etc.) so the resulting test is less likely to break the first time a developer tweaks a class name. The exported JSON is also a portable artefact you can check into version control, share with teammates, or feed into other tooling that speaks the same recording format.

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/1-global-varilables.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/1-global-varilables.md
@@ -4,8 +4,23 @@ linkTitle: 1.1 Global Variables
 weight: 1
 ---
 
-## Global Variables
+## What are global variables?
 
-View the global variable that we'll use to perform our API test. Click on **Global Variables** under the cog. The global variable named `env.encoded_auth` will be the one that we'll use to build the spotify API transaction.
+Splunk Synthetic Monitoring [**global variables**](https://docs.splunk.com/Observability/synthetics/test-config/global-variables.html) are reusable values scoped at the organisation level. Define a value once, reference it from any test by name. The two most common reasons to reach for them:
 
-![placeholder](../../img/global-variables.png)
+- **Avoid duplication.** API keys, tenant IDs, base URLs, test usernames — anything that appears in more than one test belongs in a global variable so you can update it in one place when it changes.
+- **Conceal secrets.** Variables can be marked **concealed**, which means the value is obscured in the UI and never visible to anyone reading the test definition. Concealed variables can still be referenced by tests — the test runner has access — but they can't be read back from the configuration. This is the right way to store API keys, OAuth client secrets, and HTTP Basic auth credentials.
+
+Custom variables, which we'll meet in the next two chapters, are different: they're set *during* a test run by extracting values from one response and used in subsequent steps. Globals are static, custom variables are dynamic — together they cover most data-passing patterns you'll need.
+
+## View the workshop's pre-configured global variable
+
+For this workshop a single global variable named `env.encoded_auth` has been pre-configured for you. It contains the Base64-encoded form of `client_id:client_secret` for a Spotify API client, which is exactly what Spotify's [Client Credentials OAuth flow](https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow) expects in the `Authorization: Basic …` header of a token request.
+
+Click on the cog icon at the top right of the Synthetics page and select **Global Variables** to view the list. You should see `env.encoded_auth` there.
+
+![Global Variables list with env.encoded_auth shown](../../img/global-variables.png)
+
+Notice the `env.` prefix on the variable name — global variables live under the `env.` namespace and are referenced from tests as `{{env.encoded_auth}}`. Custom variables (which we'll create during the test run) live under `custom.` and are referenced as `{{custom.access_token}}`.
+
+You don't need to edit anything here — we'll reference this variable from the authentication request in the next two chapters.

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/2-create-new-check.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/2-create-new-check.md
@@ -6,6 +6,15 @@ weight: 2
 
 ## Create a new API test
 
-Create a new API test by clicking on the {{< button style="blue" >}}Add new test{{< /button >}} button and select **API test** from the dropdown. Name the test using **your initials** followed by **Spotify API** e.g. **RWC - Spotify API**
+From the **Synthetics** landing page, click {{< button style="blue" >}}Add new test{{< /button >}} and select **API test** from the dropdown.
 
-![placeholder](../../img/new-api-check.png)
+Name the test using **your initials** followed by **Spotify API** — for example **RWC - Spotify API**. The same naming convention applies as in Part 1: prefix with your initials so the test is easy to find in a shared organisation, and include the system under test in the name so alert messages are self-describing.
+
+![Add new API test dialog with the test name field filled in](../../img/new-api-check.png)
+
+Once you click {{< button style="blue" >}}Submit{{< /button >}} you'll land on the **API Test content** page. This is where you'll add the two requests that make up our synthetic business transaction:
+
+1. **Authenticate with Spotify API** — a `POST` to the OAuth token endpoint that exchanges our client credentials for an access token, which we'll extract and stash as a custom variable.
+2. **Search for tracks** — a `GET` to the search endpoint, sending the token from step 1 as a Bearer credential, and extracting an item from the JSON response.
+
+We'll build them one at a time in the next two chapters.

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/3-authentication-request.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/3-authentication-request.md
@@ -4,33 +4,59 @@ linkTitle: 1.3 Authentication Request
 weight: 3
 ---
 
-## Add Authentication Request
+## A quick note on what we're doing
 
-Click on {{< button >}}+ Add requests{{< /button >}} and enter the request step name e.g. **Authenticate with Spotify API**.
+Before we click anything, here's the OAuth 2 flow we're modelling:
 
-![placeholder](../../img/add-request.png)
+1. Spotify (like most modern APIs) requires a short-lived bearer token on every authenticated request.
+2. To obtain that token, we make a single `POST` to the OAuth token endpoint, sending our `client_id:client_secret` (Base64-encoded) in an HTTP Basic auth header and `grant_type=client_credentials` in the body. This is the **Client Credentials grant** — the machine-to-machine variant of OAuth 2, designed for backend services that need to call an API on their own behalf rather than on behalf of a logged-in user.
+3. Spotify responds with JSON containing an `access_token`. We extract it, store it as a Synthetic Monitoring **custom variable**, and use it as the `Authorization: Bearer …` header on every subsequent request.
 
-Expand the Request section, from the drop-down change the request method to **POST** and enter the following URL:
+This same pattern is how most modern APIs authenticate service-to-service traffic, so what you build here is a template for monitoring any OAuth-protected backend.
+
+## Add the authentication request
+
+Click {{< button >}}+ Add requests{{< /button >}} and enter the request step name **Authenticate with Spotify API**. Meaningful names matter here for the same reason they did in the RBT — when a step fails, the alert message will use this name verbatim.
+
+![New API request with the step name field filled in](../../img/add-request.png)
+
+Expand the **Request** section, change the request method to **POST** from the dropdown, and enter the URL:
 
 ``` text
 https://accounts.spotify.com/api/token
 ```
 
-In the **Payload body** section enter the following:
+In the **Payload body** section enter:
 
 ``` text
 grant_type=client_credentials
 ```
 
+The `grant_type=client_credentials` value tells Spotify which OAuth flow we want. The body is `application/x-www-form-urlencoded` — the legacy form-post encoding — which is the standard for OAuth token endpoints (it predates the widespread use of JSON in API bodies).
+
 Next, add two request headers with the following key/value pairings:
 
-- **CONTENT-TYPE: application/x-www-form-urlencoded**
-- **AUTHORIZATION: Basic {{env.encoded_auth}}**
+- **CONTENT-TYPE: application/x-www-form-urlencoded** — tells Spotify how to parse the body we just supplied.
+- **AUTHORIZATION: Basic {{env.encoded_auth}}** — the workshop's pre-configured global variable from the previous chapter, expanded inline by the test runner. The runner sends the literal Base64 string; the variable name is never on the wire.
 
-Expand the **Validation** section and add the following extraction:
+## Extract the access token
 
-- **Extract** from **Response body** **JSON** **$.access_token** **as** **access_token**. 
+Spotify's response for a successful token request looks something like this:
 
-This will parse the JSON payload that is received from the Spotify API, extract the access token and store it as a custom variable.
+``` json
+{
+  "access_token": "BQDxx...long-opaque-string...",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
 
-![Add payload token](../../img/add-payload-token.png)
+We need the `access_token` value for the next step. Expand the **Validation** section of the request and add the following extraction:
+
+- **Extract** from **Response body** **JSON** **$.access_token** **as** **access_token**.
+
+The `$.access_token` is a [**JSONPath**](https://goessner.net/articles/JsonPath/) expression — the JSON equivalent of XPath. `$` is the root of the document and `.access_token` selects the top-level field. JSONPath also supports array indexing, wildcards, and filters; we'll use the array form in the next chapter.
+
+The extracted value is now available to all subsequent steps as `{{custom.access_token}}` — the `custom.` namespace is for variables produced *during* this run, in contrast to the `env.` namespace which is for organisation-level static values.
+
+![Validation panel with JSONPath extraction for $.access_token configured](../../img/add-payload-token.png)

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/4-search-request.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/4-search-request.md
@@ -5,11 +5,13 @@ weight: 4
 hidden: false
 ---
 
-## Add Search Request
+## Add the search request
 
-Click on {{< button >}}+ Add Request{{< /button >}} to add the next step. Name the step **Search for Tracks named "Up around the bend"**.
+Now that we have a valid access token, we'll use it. Click {{< button >}}+ Add Request{{< /button >}} to add the next step. Name the step **Search for tracks named "Up around the bend"**.
 
-Expand the **Request** section and change the request method to **GET** and enter the following URL:
+This is the [Spotify Search endpoint](https://developer.spotify.com/documentation/web-api/reference/search). The query string parameters say: search for tracks (`type=track`) matching the phrase "Up around the bend", starting from the first result (`offset=0`), and return at most 5 (`limit=5`). Spotify URL-encodes the query phrase, so spaces become `%20`.
+
+Expand the **Request** section, change the request method to **GET**, and enter the URL:
 
 ``` text
 https://api.spotify.com/v1/search?q=Up%20around%20the%20bend&type=track&offset=0&limit=5
@@ -17,15 +19,25 @@ https://api.spotify.com/v1/search?q=Up%20around%20the%20bend&type=track&offset=0
 
 Next, add two request headers with the following key/value pairings:
 
-- **CONTENT-TYPE: application/json**
-- **AUTHORIZATION: Bearer {{custom.access_token}}**
+- **CONTENT-TYPE: application/json** — declares the request body format. Strictly speaking, GET requests don't carry a body and so this header is informational only here, but it's polite to send and Spotify won't object.
+- **AUTHORIZATION: Bearer {{custom.access_token}}** — this is where the magic happens. `{{custom.access_token}}` expands at run time to the token we extracted in the previous step, so the chain "auth → use token" is now wired up.
 
-![Add search request](../../img/add-search-request.png)
+This is the core of the multi-step pattern: any value extracted in step N is available by name in step N+1, N+2, etc. You can extract as many values per step as you need, and you can chain arbitrarily deep — auth, then user lookup, then resource fetch, then asserted state change, then cleanup.
+
+![Search request step with URL and headers configured](../../img/add-search-request.png)
+
+## Extract a track ID
+
+The search response is a JSON document with a `tracks.items` array, each entry containing a track ID, name, artist, album, and so on. We'll extract the ID of the first matching track.
 
 Expand the **Validation** section and add the following extraction:
 
 - **Extract** from **Response body** **JSON** **$.tracks.items[0].id** **as** **track.id**.
 
-![Add search payload](../../img/add-search-payload.png)
+The JSONPath `$.tracks.items[0].id` walks the response: start at the root (`$`), go into the `tracks` object, then into the `items` array, take the first element (`[0]`), and read its `id` field. JSONPath's array syntax also supports negative indices (`[-1]` for the last), slices (`[0:5]`), and filter expressions, which is useful when you want to assert a property of a specific item rather than just the first.
 
-Click on {{< button style="blue" >}}< Return to test{{< /button >}} to return to the test configuration page. And then click {{< button style="blue" >}}Save{{< /button >}} to save the API test.
+In this workshop we extract the ID but don't use it again — in a production check you'd typically add a third step that calls `GET /v1/tracks/{{custom.track.id}}` and asserts that the response body contains the artist and album you expect. That would catch a regression where Spotify's catalogue changes or where the search ranking degrades.
+
+![Validation panel with JSONPath extraction for $.tracks.items[0].id configured](../../img/add-search-payload.png)
+
+Click {{< button style="blue" >}}< Return to test{{< /button >}} to return to the test configuration page, then click {{< button style="blue" >}}Save{{< /button >}} to save the API test.

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/5-view-results.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/5-view-results.md
@@ -7,12 +7,46 @@ hidden: false
 
 ## View results
 
-Wait for a few minutes for the test to provision and run. Once you see the test has run successfully, click on the run to view the test results:
+Wait a few minutes for the test to provision and dispatch its first run. Once you see at least one successful run on the test dashboard, click it to drill into the run results.
 
-![API test result](../../img/api-test-result.png)
+![API test result page showing the two-step Spotify transaction with response headers and request timing breakdown](../../img/api-test-result.png)
 
-## 6. Resources
+The API test results page is laid out like a slimmed-down version of the Real Browser Test results — the same general anatomy, but without the screenshots, video, or web vitals (none of which apply, since no browser ran).
 
-- [How to Create an API Test](https://docs.splunk.com/Observability/synthetics/api-test/set-up-api-test.html)
+## Result header
 
-- [API Test Overview](https://docs.splunk.com/Observability/synthetics/api-test/api-test.html)
+At the top: **Status**, **Location**, **Timestamp**, and **Total duration**. Notice how short the total duration is compared to the RBT — typically tens to hundreds of milliseconds for the whole multi-step transaction. That's the cost-frequency advantage of API tests in action.
+
+## Request timeline
+
+A horizontal bar for each request in the transaction, in execution order. Green is a successful step (any 2xx response that also satisfies your validation rules); red is a failure. The bar lengths are proportional to each request's total duration, so you can spot which step in a chain is the slow one at a glance.
+
+## Request detail panes
+
+Click any request in the timeline (or the list on the left) to open three tabs:
+
+- **Response** — full response body, headers, and status code. Useful for one-off debugging ("what is Spotify actually returning?") and for verifying that your extraction rules are pointing at the right field. The response body is captured every run, so you can compare today's response against last week's if behaviour has changed.
+- **Request** — exactly what was sent on the wire: method, URL (with global variables already expanded so you can verify the substitution), headers, and body. Sensitive values from concealed variables are still concealed here.
+- **Connection info** — TLS version, cipher suite, certificate chain. Worth a look when you're debugging certificate or protocol-handshake issues.
+
+## Request info — the timing breakdown
+
+The right-hand sidebar is the single most useful diagnostic view in the page. For the selected request, it breaks the total duration down into its component phases:
+
+- **DNS time** — how long it took to resolve the hostname. Sudden spikes here usually mean a regional DNS provider issue.
+- **TCP Connect time** — opening the TCP socket to the server. Sudden spikes usually mean network congestion or a target server under load.
+- **TLS time** — completing the TLS handshake. Spikes here can indicate certificate-chain issues or TLS renegotiation thrash.
+- **Wait time** — server processing time, between the request being fully sent and the first byte of the response coming back. This is **server-side latency** and is usually the most actionable number on the page — a regression here points squarely at the API team.
+- **Receive time** — how long it took to read the response body off the wire. Large for big response payloads.
+- **Duration** — total wall-clock time for this single request.
+- **Response Size** — bytes received. Watch for unexpected growth — schema changes that bloat responses are a common cause of subtle latency regressions.
+
+Every one of these is also a time series you can chart, dashboard, and alert on. A typical production setup creates detectors on (a) overall run failure, (b) total run duration P95, and (c) the Wait time of any request whose backend SLO matters.
+
+## Where to go from here
+
+- [How to Create an API Test](https://docs.splunk.com/Observability/synthetics/api-test/set-up-api-test.html) — the official docs walk through every option in detail, including validation rules we didn't cover here.
+- [API Test Overview](https://docs.splunk.com/Observability/synthetics/api-test/api-test.html) — concept-level introduction with all the supported request types and validation operators.
+- [Synthetic Monitoring detectors](https://docs.splunk.com/Observability/alerts-detectors-notifications/synthetics-detectors.html) — turn this run's metrics into alerts wired into the same notification channels as the rest of your Observability Cloud detectors.
+
+**Congratulations!** You've built a complete multi-step API test from scratch, including an OAuth-authenticated business transaction. The same auth-then-action pattern — with whatever JSON extraction and validation rules your real backends need — covers the bulk of what teams use Splunk Synthetic Monitoring API Tests for in production.

--- a/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/_index.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/2-api-test/_index.md
@@ -5,8 +5,25 @@ weight: 2
 hidden: false
 ---
 
-The API Test provides a flexible way to check the functionality and performance of API endpoints. The shift toward API-first development has magnified the necessity to monitor the back-end services that provide your core front-end functionality.
+The **API Test** provides a flexible way to check the functionality and performance of API endpoints. The shift toward API-first development has magnified the necessity to monitor the back-end services that provide your core front-end functionality — by the time a regression surfaces in a Real Browser Test, the underlying API has often already been broken for a while.
 
-Whether you're interested in testing the multi-step API interactions or you want to gain visibility into the performance of your endpoints, the API Test can help you accomplish your goals.
+Whether you're interested in testing multi-step API interactions or you want to gain visibility into the performance of individual endpoints, the API Test can help you accomplish your goals.
 
 ![API test result](../img/api-test-result.png)
+
+## How an API Test differs from a Real Browser Test
+
+API Tests are **headless** — there's no browser, no JavaScript engine, no DOM. The test runner makes raw HTTP requests, parses the responses, and runs your validation rules against them. That has three practical consequences:
+
+- **Cheaper and faster per run.** A typical API run completes in tens or hundreds of milliseconds rather than the 10–30 seconds an RBT takes. This makes higher-frequency monitoring feasible — many teams run critical API tests every minute.
+- **No rendering signal.** You can't measure paint times or layout shifts because nothing's being rendered. If you need to know how a real user *experiences* the result, you still want an RBT covering that journey.
+- **Easier to chain steps.** Variables extracted from one response can be referenced by name in the next request, which makes it natural to model real business transactions like "log in, fetch user profile, perform an action, verify the result."
+
+## When to reach for an API Test
+
+- **Backend SLOs.** Endpoint availability and latency for the APIs your services depend on.
+- **Authentication flows.** OAuth token issuance, SAML assertion exchange, session creation — all multi-step, all critical, all easier to validate explicitly than by inference from a browser test.
+- **JSON contract validation.** Asserting that a response includes a specific field, that an array has the expected number of elements, or that a value matches a regex — catches breaking schema changes before they hit clients.
+- **Synthetic business transactions.** Sequences of API calls that represent a real user action, end to end, even when no human is currently performing one.
+
+In this chapter you'll build a two-step API Test against the public Spotify Web API. The first step performs an **OAuth 2 Client Credentials** authentication and extracts the bearer token from the response. The second step uses that token to call the Spotify search endpoint and extracts the ID of the first matching track. The same pattern — auth followed by an authenticated action — covers a huge slice of real backend monitoring use cases.

--- a/content/en/ninja-workshops/4-synthetics-scripting/_index.md
+++ b/content/en/ninja-workshops/4-synthetics-scripting/_index.md
@@ -17,3 +17,20 @@ With **Splunk Synthetic Monitoring** you can:
 - Detect and resolve issues fast across critical user flows, business transactions and API endpoints
 - Prevent web performance issues from affecting customers with an intelligent web optimization engine
 - And improve the performance of all page resources and third-party dependencies
+
+## What you'll build in this workshop
+
+This workshop is split into two complementary parts that mirror how teams actually adopt Splunk Synthetic Monitoring in production:
+
+- **Part 1 — Real Browser Test.** You'll use the [**Chrome DevTools Recorder**](https://developer.chrome.com/docs/devtools/recorder/) to capture a real user journey through a demo Online Boutique storefront — browsing a product, adding it to the cart, placing an order. You'll export that journey as JSON, import it into Splunk Synthetic Monitoring, schedule it to run from multiple global locations, and learn how to read the resulting performance data.
+- **Part 2 — API Test.** You'll build a multi-step API check against the Spotify Web API: authenticate using OAuth 2 client credentials, chain the resulting bearer token into a search request, and validate the response. This is the same pattern you'd use to monitor your own backend SLOs end to end.
+
+By the end of the 45 minutes you should be comfortable creating, configuring, and interpreting both check types — and you'll know when to reach for which.
+
+## Prerequisites
+
+- Google Chrome installed locally (for the recorder portion).
+- Access to a Splunk Observability Cloud organisation with the **Synthetics** tab enabled.
+- Approximately 45 minutes; tests will keep running in the background after the workshop ends, so leave them in place if you'd like to watch trends accumulate.
+
+> Synthetic Monitoring also offers a third check type — **Uptime Tests** — for lightweight port and HTTP availability checks. We won't build one in this workshop, but you'll see it referenced in the UI; the [Uptime test documentation](https://docs.splunk.com/Observability/synthetics/uptime-test/uptime-test.html) is a good follow-on read.


### PR DESCRIPTION
## Description

This workshop was a bit thin on the ground content wise. I worked with Claude to pad it out and provide additional insights in to the two test types that are created.

Also, it will be super easy to slot in the backup selector paths feature when it is released as the Chrome Recorder generates these by default.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Markdown Lint passes locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
