### PR TITLE
Refine Solarwinds notifications section and scope kubectl restart in TE Integration Lab

### DIFF
--- a/content/en/scenarios/network-event-intelligence/4-configure-solarwinds-notifications/_index.md
+++ b/content/en/scenarios/network-event-intelligence/4-configure-solarwinds-notifications/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Configure SolarWinds Notifications
-linkTitle: 4. Configure SolarWinds Notifications
+title: Configure Solarwinds Notifications
+linkTitle: 4. Configure Solarwinds Notifications
 weight: 4
 time: 5 minutes
 authors: ["Chris Putnam", "Sam Scudere-Weiss", "Tim Hard"]
@@ -10,17 +10,17 @@ authors: ["Chris Putnam", "Sam Scudere-Weiss", "Tim Hard"]
 
 ## Adding a Second Alert Source
 
-A key goal of this workshop is demonstrating cross-vendor alert correlation. Cisco Catalyst Center covers your Cisco infrastructure, but many enterprise networks also rely on third-party monitoring tools like SolarWinds to track non-Cisco devices, WAN links, and broader network health metrics. When both sources raise alerts about the same site or time window, ITSI should be able to group them into a single episode rather than generating separate noise for each.
+A key goal of this workshop is demonstrating cross-vendor alert correlation. Cisco Catalyst Center covers your Cisco infrastructure, but many enterprise networks also rely on third-party monitoring tools like Solarwinds to track non-Cisco devices, WAN links, and broader network health metrics. When both sources raise alerts about the same site or time window, ITSI should be able to group them into a single episode rather than generating separate noise for each.
 
-The **SolarWinds Add-on for Splunk** can provide deep asset context, but for this use case SolarWinds alerts are delivered directly to the Splunk HTTP Event Collector. The Content Pack for Cisco Enterprise Networks includes a pre-built integration template that normalizes these alerts so they are recognized by ITSI in the same way as Catalyst Center alerts.
+The **Solarwinds Add-on for Splunk** can provide deep asset context, but for this use case Solarwinds alerts are delivered directly to the Splunk HTTP Event Collector. ITSI includes a pre-built integration template for Solarwinds that normalizes these alerts so they are recognized by ITSI in the same way as other event sources, such as Catalyst Center alerts.
 
-In this section you will install the SolarWinds Content Pack and configure the inbound notification connection, completing the two-source alert pipeline that the NEAP in the next section will correlate.
+In this section you will configure the **Solarwinds Inbound Notification** connection, completing the two-source alert pipeline that the **Notable Event Aggregation Policy** in the next section will correlate.
 
 ## What You'll Do in This Section
 
 By the end of this section you will have:
 
-- Installed the **SolarWinds Content Pack** and configured the inbound notification connection
-- Verified that SolarWinds alerts are flowing into ITSI as normalized notable events
+- Configured the **Solarwinds Inbound Notification** connection which will create Notable Events in ITSI for these alerts
+- Verified that Solarwinds alerts are flowing into ITSI as normalized notable events
 
 </div>

--- a/content/en/scenarios/thousandeyes-integration/4-distributed-tracing/1_configure_instrumentation.md
+++ b/content/en/scenarios/thousandeyes-integration/4-distributed-tracing/1_configure_instrumentation.md
@@ -196,7 +196,7 @@ To do that:
 {{< tabs >}}
 {{% tab title="Script" %}}
 ```bash
-kubectl rollout restart deployment
+kubectl rollout restart deployment -l app.kubernetes.io/part-of=spring-petclinic
 ```
 {{% /tab %}}
 {{% tab title="Example Output" %}}


### PR DESCRIPTION
## Summary

- **`network-event-intelligence/4-configure-solarwinds-notifications/_index.md`**: Reworked the intro to clarify that ITSI includes a pre-built Solarwinds integration template, so this section configures the Inbound Notification connection rather than installing a Content Pack. Updated the "What You'll Do" bullets to match.
- **`thousandeyes-integration/4-distributed-tracing/1_configure_instrumentation.md`**: Scoped `kubectl rollout restart deployment` to `-l app.kubernetes.io/part-of=spring-petclinic` so the restart only affects the petclinic deployments and not anything else in the namespace.

## Test plan

- [ ] Build the Hugo site locally and visually verify both pages render correctly
- [ ] Walk through the Solarwinds notifications section and confirm the steps match the new (no Content Pack) flow
- [ ] Run the updated `kubectl rollout restart` command in a test cluster and confirm only `spring-petclinic` deployments restart