### PR TITLE
Modernize release pipeline for the hugo-theme-splunk-workshop migration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 6.71
 commit = True
-Tag = True
+tag = false
 parse = v?(?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
 tag_message = "Version {new_version}"

--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.155.3'
+          hugo-version: '0.161.1'
           extended: true
 
       - name: Setup yq
@@ -62,11 +62,14 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git pull --rebase
 
-          TAG=$(bumpversion --list "${{ inputs.release_type }}" | awk -F= '/new_version=/ { print $2 }')
+          TAG=$(bump-my-version show new_version --increment "${{ inputs.release_type }}")
           echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
-          BASE_URL="$(yq .baseURL hugo.yaml)"
+          BASE_URL="$(yq -p=toml .baseURL hugo.toml)"
           echo "base_url=${BASE_URL}" >> $GITHUB_OUTPUT
+
+          # Bump version files and commit (tag is handled below, per .bumpversion.cfg `tag = false`)
+          bump-my-version bump "${{ inputs.release_type }}"
 
           # Update README with new release link
           awk "/Latest versions of the workshop are:/ { print; print \"- [v${TAG}](https://splunk.github.io/observability-workshop/)\";next }1" README.md |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 terraform 1.3.7
-hugo 0.155.3
+hugo 0.161.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 wheel
-bump2version>=1.0.1
+bump-my-version


### PR DESCRIPTION
- Bump Hugo to 0.161.1 (workflow + .tool-versions) — required by the new theme
- Switch yq to TOML mode and read baseURL from hugo.toml (was hugo.yaml)
- Migrate from the unmaintained bump2version to bump-my-version, which works on Python 3.12 and is actively maintained
- Set `tag = false` in .bumpversion.cfg (bump-my-version uses lowercase) and tag explicitly in the workflow after `git commit --amend`, so the release tag points at the final "Releasing v…" commit instead of the orphan bump commit the previous flow produced

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Markdown Lint passes locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
