### PR TITLE
updated travel planner demo v2 to include deterministic quality issue…

### DIFF
--- a/workshop/demos/travel-agent-demo-v2/README.md
+++ b/workshop/demos/travel-agent-demo-v2/README.md
@@ -76,6 +76,27 @@ Send a request including poison config that forces a PCI violation:
     }'
 ```
 
+Send a request including poison config that uses deterministic behavior (i.e. always 
+inject hallucination and PCI violations, without randomness)
+
+``` bash
+  curl http://localhost:8080/travel/plan \
+    -H "Content-Type: application/json" \
+    -d '{
+      "origin": "New York",
+      "destination": "London",
+      "user_request": "We are planning a week-long trip to New York from London. Looking for boutique hotel, business-class flights and unique experiences.",
+      "travelers": 2,
+      "poison_config": {
+          "prob": "1.0",
+          "types": ["pci_violation"],
+          "max": "1",
+          "seed": "9999",
+          "deterministic": "true"
+      }
+    }'
+```
+
 ## Build Docker Images
 
 The following commands were used to build Docker images for each of the application components. 
@@ -86,8 +107,8 @@ To build the travel agent application image:
 
 ``` bash
 cd app-with-ai-defense
-docker build --platform linux/amd64 -t ghcr.io/splunk/travel-planner-demo-v2:1.0 .
-docker push ghcr.io/splunk/travel-planner-demo-v2:1.0
+docker build --platform linux/amd64 -t ghcr.io/splunk/travel-planner-demo-v2:1.1 .
+docker push ghcr.io/splunk/travel-planner-demo-v2:1.1
 ```
 
 ### Load Generator
@@ -96,6 +117,6 @@ To build the travel agent load generator image:
 
 ``` bash
 cd loadgen
-docker build --platform linux/amd64 -t ghcr.io/splunk/travel-planner-loadgen-v2:1.0 .
-docker push ghcr.io/splunk/travel-planner-loadgen-v2:1.0
+docker build --platform linux/amd64 -t ghcr.io/splunk/travel-planner-loadgen-v2:1.1 .
+docker push ghcr.io/splunk/travel-planner-loadgen-v2:1.1
 ```

--- a/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/README.md
+++ b/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/README.md
@@ -58,7 +58,7 @@ pip install -r requirements.txt
 python main.py
 ```
 
-Send a request including poison config and a (fake) credit card number:
+Send a request including poison config:
 
 ``` bash
   curl http://localhost:8080/travel/plan \
@@ -66,13 +66,33 @@ Send a request including poison config and a (fake) credit card number:
     -d '{
       "origin": "New York",
       "destination": "London",
-      "user_request": "We are planning a week-long trip to New York from London. Looking for boutique hotel, business-class flights and unique experiences. My credit card number is 4111 1111 1111 1111",
+      "user_request": "We are planning a week-long trip to New York from London. Looking for boutique hotel, business-class flights and unique experiences.",
       "travelers": 2,
       "poison_config": {
           "prob": "1.0",
-          "types": ["hallucination","irrelevance"],
+          "types": ["hallucination","pci_violation"],
           "max": "1",
           "seed": "9999"
+      }
+    }'
+```
+
+Send a request including poison config with deterministic behavior:
+
+``` bash
+  curl http://localhost:8080/travel/plan \
+    -H "Content-Type: application/json" \
+    -d '{
+      "origin": "New York",
+      "destination": "London",
+      "user_request": "We are planning a week-long trip to New York from London. Looking for boutique hotel, business-class flights and unique experiences.",
+      "travelers": 2,
+      "poison_config": {
+          "prob": "1.0",
+          "types": ["hallucination","pci_violation"],
+          "max": "1",
+          "seed": "9999",
+          "deterministic": "true"
       }
     }'
 ```

--- a/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/deployment-openai.yaml
+++ b/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/deployment-openai.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: travel-planner-langchain
-          image: ghcr.io/splunk/travel-planner-demo-v2:1.0
+          image: ghcr.io/splunk/travel-planner-demo-v2:1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/deployment.yaml
+++ b/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: travel-planner-langchain
-          image: ghcr.io/splunk/travel-planner-demo-v2:1.0
+          image: ghcr.io/splunk/travel-planner-demo-v2:1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/main.py
+++ b/workshop/demos/travel-agent-demo-v2/app-with-ai-defense/main.py
@@ -458,6 +458,7 @@ def _poison_config(
         max_snippets = int(custom_config.get("max", 2))
         seed = custom_config.get("seed")
         rng = random.Random(int(seed)) if seed is not None else random.Random()
+        deterministic = custom_config.get("deterministic")
     else:
         prob = float(os.getenv("TRAVEL_POISON_PROB", "0.8"))
         types_raw = os.getenv(
@@ -480,11 +481,14 @@ def _poison_config(
         max_snippets = int(os.getenv("TRAVEL_POISON_MAX", "2"))
         seed = os.getenv("TRAVEL_POISON_SEED")
         rng = random.Random(int(seed)) if seed is not None else random.Random()
+        deterministic = False
+
     return {
         "prob": max(0.0, min(prob, 1.0)),
         "types": types,
         "max": max_snippets,
-         "rng": rng,
+        "rng": rng,
+        "deterministic": deterministic
     }
 
 
@@ -549,16 +553,25 @@ def maybe_add_quality_noise(
 
     if random.random() > cfg["prob"]:
         return base_prompt
-    # choose subset
-    available = cfg["types"][:]
-    rng.shuffle(available)
-    count = rng.randint(1, min(cfg["max"], len(available)))
-    chosen = available[:count]
-    snippets = [_generate_poison_snippet(kind, agent_name) for kind in chosen]
-    # Record events
-    state["poison_events"].extend([f"{agent_name}:{kind}" for kind in chosen])
-    injected = base_prompt + "\n\n" + "\n".join(snippets) + "\n"
-    return injected
+
+    if cfg.get("deterministic"):
+        chosen = ["hallucination","pci_violation"]
+        snippets = [_generate_poison_snippet(kind, agent_name) for kind in chosen]
+        # Record events
+        state["poison_events"].extend([f"{agent_name}:{kind}" for kind in chosen])
+        injected = base_prompt + "\n\n" + "\n".join(snippets) + "\n"
+        return injected
+    else:
+        # choose subset
+        available = cfg["types"][:]
+        rng.shuffle(available)
+        count = rng.randint(1, min(cfg["max"], len(available)))
+        chosen = available[:count]
+        snippets = [_generate_poison_snippet(kind, agent_name) for kind in chosen]
+        # Record events
+        state["poison_events"].extend([f"{agent_name}:{kind}" for kind in chosen])
+        injected = base_prompt + "\n\n" + "\n".join(snippets) + "\n"
+        return injected
 
 
 # ---------------------------------------------------------------------------

--- a/workshop/demos/travel-agent-demo-v2/loadgen/client.py
+++ b/workshop/demos/travel-agent-demo-v2/loadgen/client.py
@@ -45,7 +45,7 @@ POISON_TYPES = [
 ]
 
 
-def generate_random_poison_config() -> dict:
+def generate_random_poison_config(add_deterministic_quality_issues: bool = False) -> dict:
     """Generate a random poison configuration for testing."""
     # Random probability between 0.5 and 1.0
     prob = round(random.uniform(0.5, 1.0), 2)
@@ -62,6 +62,7 @@ def generate_random_poison_config() -> dict:
         "types": types,
         "max": max_snippets,
         "seed": str(random.randint(1000, 9999)),
+        "deterministic": add_deterministic_quality_issues
     }
 
 
@@ -81,6 +82,7 @@ def generate_travel_request(origin: str, destination: str) -> str:
 
 
 def run_client(
+    add_deterministic_quality_issues: bool = False,
     use_poison: bool = True,
     custom_origin: Optional[str] = None,
     custom_destination: Optional[str] = None,
@@ -98,12 +100,13 @@ def run_client(
     # Generate poison config if requested
     poison_config = None
     if use_poison:
-        poison_config = generate_random_poison_config()
+        poison_config = generate_random_poison_config(add_deterministic_quality_issues)
         print("\n💉 Poison Configuration:")
         print(f"  Probability: {poison_config['prob']}")
         print(f"  Types: {', '.join(poison_config['types'])}")
         print(f"  Max snippets: {poison_config['max']}")
         print(f"  Seed: {poison_config['seed']}")
+        print(f"  Deterministic: {poison_config['deterministic']}")
 
     # Generate user request
     user_request = generate_travel_request(origin, destination)
@@ -198,6 +201,11 @@ def main():
         description="Travel Planner MCP Client - Request travel itineraries with optional quality evaluation"
     )
     parser.add_argument(
+        "--add-deterministic-quality-issues",
+        action="store_true",
+        help="Add deterministic quality issues (i.e. no randomness)",
+    )
+    parser.add_argument(
         "--no-poison",
         action="store_true",
         help="Disable poison configuration (no quality degradation testing)",
@@ -217,6 +225,7 @@ def main():
 
     try:
         run_client(
+            add_deterministic_quality_issues=args.add_deterministic_quality_issues,
             use_poison=not args.no_poison,
             custom_origin=args.origin,
             custom_destination=args.destination,

--- a/workshop/demos/travel-agent-demo-v2/loadgen/cronjob.yaml
+++ b/workshop/demos/travel-agent-demo-v2/loadgen/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: mcp-client
-              image: ghcr.io/splunk/travel-planner-loadgen-v2:1.0
+              image: ghcr.io/splunk/travel-planner-loadgen-v2:1.1
               imagePullPolicy: Always
               env:
                 # Flask Server URL - using k8s service
@@ -29,6 +29,7 @@ spec:
               command:
                 - python
                 - client.py
+                - -add-deterministic-quality-issues
                 #- --no-poison
               resources:
                 requests:


### PR DESCRIPTION
Previously, the travel planner v2 demo only offered the option to add quality issues randomly. For some scenarios, more deterministic behavior is required. So, this change adds a new option to add deterministic quality issues. Specifically, when this option is enabled, hallucination and PCI violation issues will be added to each request.  