### PR TITLE
Clear stale go vcs cache before Hugo build

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -81,6 +81,9 @@ jobs:
           git tag -a "v${TAG}" -m "Version ${TAG}"
           git push --follow-tags origin main || { echo 'Push failed. git pull --rebase from upstream and attempt another release.'; exit 1; }
 
+      - name: Clear stale go vcs cache
+        run: rm -rf /tmp/hugo_cache/modules/filecache/modules/pkg/mod/cache/vcs
+
       - name: Build Hugo site
         run: |
           hugo --minify --destination "public" --baseURL "${{ steps.bumpversion.outputs.base_url }}observability-workshop" --noChmod --cacheDir /tmp/hugo_cache


### PR DESCRIPTION
## Summary
- Adds a step to `deploy-workshop.yml` that removes `/tmp/hugo_cache/modules/filecache/modules/pkg/mod/cache/vcs` before `hugo` runs.

## Why
When `go.sum` bumps the theme pseudo-version, the cache key misses and `restore-keys` falls back to the previous cache. The cached shallow clone of the theme then conflicts with `git fetch --unshallow`, causing Hugo to fail with:

```
fatal: shallow file has changed since we read it
```

This is what broke the last deploy run after #540 landed. Wiping just the vcs subdir on each run preserves the module download cache (still fast) while removing the conflict source.

## Test plan
- [ ] Trigger the **Deploy Workshop to GitHub Pages** workflow and confirm `hugo` no longer fails at `go mod download`.