### PR TITLE
Theme bump to v0.10.6 and assorted content fixes

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -88,50 +88,6 @@ jobs:
         run: |
           hugo --minify --destination "public" --baseURL "${{ steps.bumpversion.outputs.base_url }}observability-workshop" --noChmod --cacheDir /tmp/hugo_cache
 
-      - name: Create redirect handler for old URLs
-        run: |
-          cat > public/404.html << 'EOF'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8">
-            <title>Redirecting...</title>
-            <script>
-              // Handle redirects from old versioned URLs to new root URLs
-              (function() {
-                var path = window.location.pathname;
-
-                // Match /observability-workshop/latest/ or /observability-workshop/v{version}/ patterns
-                var versionPattern = /^\/observability-workshop\/(latest|v[\d.]+)\/(.*)/;
-                var match = path.match(versionPattern);
-
-                if (match) {
-                  // Extract the path after the version (e.g., "en/index.html")
-                  var newPath = match[2];
-
-                  // Preserve query string and hash if present
-                  var newUrl = window.location.origin + '/observability-workshop/' + newPath + window.location.search + window.location.hash;
-
-                  // Redirect to new URL
-                  window.location.replace(newUrl);
-                } else {
-                  // If no version pattern matched, show a friendly 404 message
-                  document.write('<h1>404 - Page Not Found</h1>');
-                  document.write('<p>The page you are looking for does not exist.</p>');
-                  document.write('<p>Visit the <a href="/observability-workshop/">Splunk Observability Workshop homepage</a>.</p>');
-                }
-              })();
-            </script>
-            <noscript>
-              <meta http-equiv="refresh" content="0; url=/observability-workshop/">
-            </noscript>
-          </head>
-          <body>
-            <p>Redirecting... If you are not redirected, <a href="/observability-workshop/">click here</a>.</p>
-          </body>
-          </html>
-          EOF
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.10.4/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.10.6/assets/*"
    ]
   }
  }

--- a/content/en/conf/1-advanced-collector/2-building-resilience/2-1-configuration.md
+++ b/content/en/conf/1-advanced-collector/2-building-resilience/2-1-configuration.md
@@ -83,7 +83,7 @@ graph LR
     %% Links
     subID1:::sub-metrics
     subgraph " "
-      subgraph subID1[**Metrics**]
+      subgraph subID1["`**Metrics**`"]
       direction LR
       REC1 -- > PRO1
       PRO1 -- > PRO2

--- a/content/en/conf/1-advanced-collector/3-dropping-spans/3-1-configuration.md
+++ b/content/en/conf/1-advanced-collector/3-dropping-spans/3-1-configuration.md
@@ -57,7 +57,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 -- > PRO1
       PRO1 -- > PRO4

--- a/content/en/conf/1-advanced-collector/4-sensitive-data/4-1-configuration.md
+++ b/content/en/conf/1-advanced-collector/4-sensitive-data/4-1-configuration.md
@@ -104,7 +104,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 -- > PRML
       PRML -- > PRUP

--- a/content/en/conf/1-advanced-collector/6-routing-data/6-2-pipelines.md
+++ b/content/en/conf/1-advanced-collector/6-routing-data/6-2-pipelines.md
@@ -81,7 +81,7 @@ graph LR
     subID3:::sub-traces
     subgraph " "
     direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       REC1 -- > ROUTE1
       end
       subgraph subID2[**Traces/standard**]

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/1-agent/1-3-fileexporter/_index.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/1-agent/1-3-fileexporter/_index.md
@@ -81,7 +81,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO2

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/2-gateway/2-2-configure-agent.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/2-gateway/2-2-configure-agent.md
@@ -93,7 +93,7 @@ graph LR
     %% Links
     subID1:::sub-metrics
     subgraph " "
-      subgraph subID1[**Metrics**]
+      subgraph subID1["`**Metrics**`"]
       direction LR
       REC1 --> PRO1
       REC2 --> PRO1

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/4-building-resilience/4-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/4-building-resilience/4-1-configuration.md
@@ -74,7 +74,7 @@ graph LR
     %% Links
     subID1:::sub-metrics
     subgraph " "
-      subgraph subID1[**Metrics**]
+      subgraph subID1["`**Metrics**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO2

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/5-dropping-spans/5-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/5-dropping-spans/5-1-configuration.md
@@ -56,7 +56,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO4

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/6-sensitive-data/6-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/6-sensitive-data/6-1-configuration.md
@@ -107,7 +107,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRML
       PRML --> PRUP

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/8-routing-data/8-2-pipelines.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/8-routing-data/8-2-pipelines.md
@@ -83,7 +83,7 @@ graph LR
     subID3:::sub-traces
     subgraph " "
     direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       REC1 --> ROUTE1
       end
       subgraph subID2[**Traces/standard**]

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/9-sum-count/9-2-sum.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/9-sum-count/9-2-sum.md
@@ -120,7 +120,7 @@ graph LR
     subID2:::sub-metrics
     subgraph " " 
       direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PROA
@@ -134,7 +134,7 @@ graph LR
       PRO5 --> ROUTE1
       end
       
-      subgraph subID2[**Metrics**]
+      subgraph subID2["`**Metrics**`"]
       direction LR
       ROUTE1 --> ROUTE3
       ROUTE3 --> PRO2       

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/9-sum-count/_index.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector-old/9-sum-count/_index.md
@@ -169,7 +169,7 @@ graph LR
       PRO5 --> EXP2
       end
       
-      subgraph subID2[**Metrics**]
+      subgraph subID2["`**Metrics**`"]
       direction LR
       ROUTE1 --> ROUTE2       
       ROUTE2 --> PRO2

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/2-building-resilience/2-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/2-building-resilience/2-1-configuration.md
@@ -69,7 +69,7 @@ service:
 
 Validate the **Agent** configuration using **[otelbin.io](https://www.otelbin.io/)**. For reference, the `metrics:` section of your pipelines will look similar to this:
 
-```mermaid
+{{% mermaid %}}
 %%{init:{"fontFamily":"monospace"}}%%
 graph LR
     %% Nodes
@@ -83,7 +83,7 @@ graph LR
     %% Links
     subID1:::sub-metrics
     subgraph " "
-      subgraph subID1[**Metrics**]
+      subgraph subID1["`**Metrics**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO2
@@ -97,4 +97,4 @@ classDef receiver,exporter fill:#8b5cf6,stroke:#333,stroke-width:1px,color:#fff;
 classDef processor fill:#6366f1,stroke:#333,stroke-width:1px,color:#fff;
 classDef con-receive,con-export fill:#45c175,stroke:#333,stroke-width:1px,color:#fff;
 classDef sub-metrics stroke:#38bdf8,stroke-width:1px, color:#38bdf8,stroke-dasharray: 3 3;
-```
+{{% /mermaid %}}

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/3-dropping-spans/3-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/3-dropping-spans/3-1-configuration.md
@@ -56,7 +56,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO4

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/4-sensitive-data/4-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/4-sensitive-data/4-1-configuration.md
@@ -102,7 +102,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRML
       PRML --> PRUP

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/5-transform-data/5-1-configuration.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/5-transform-data/5-1-configuration.md
@@ -96,7 +96,7 @@ graph LR
     %% Links
     subID1:::sub-logs
     subgraph " "
-      subgraph subID1[**Logs**]
+      subgraph subID1["`**Logs**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO3

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/6-routing-data/6-2-pipelines.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/6-routing-data/6-2-pipelines.md
@@ -80,10 +80,10 @@ graph LR
     subID3:::sub-traces
     subgraph " "
     direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       REC1 --> ROUTE1
       end
-      subgraph subID2[**Traces/route2-security**]
+      subgraph subID2["`**Traces/route2-security**`"]
       ROUTE1 --> ROUTE2
       ROUTE2 --> PRO1
       PRO1 --> PRO3
@@ -91,7 +91,7 @@ graph LR
       PRO5 --> EXP1
       PRO5 --> EXP2
       end
-      subgraph subID3[**Traces/route1-regular**]
+      subgraph subID3["`**Traces/route1-regular**`"]
       ROUTE1 --> ROUTE3
       ROUTE3 --> PRO2
       PRO2 --> PRO4

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/7-2-sum.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/7-2-sum.md
@@ -116,43 +116,44 @@ graph LR
     ROUTE3(&nbsp;sum&nbsp;<br>fa:fa-route<br> ):::con-receive
 
     %% Links
-    subID1:::sub-traces
-    subID2:::sub-metrics
-    subgraph " " 
+    subgraph wrapper[" "]
       direction LR
-      subgraph subID1[**Traces**]
-      direction LR
-      REC1 --> PRO1
-      PRO1 --> PROA
-      PROA --> PROB
-      PROB --> PRO7
-      PRO7 --> PRO3
-      PRO3 --> PRO5 
-      PRO5 --> EXP1
-      PRO5 --> EXP2
-      PRO5 --> EXP5
-      PRO5 --> ROUTE1
+      subgraph subID1["`**Traces**`"]
+        direction LR
+        REC1 --> PRO1
+        PRO1 --> PROA
+        PROA --> PROB
+        PROB --> PRO7
+        PRO7 --> PRO3
+        PRO3 --> PRO5
+        PRO5 --> EXP1
+        PRO5 --> EXP2
+        PRO5 --> EXP5
+        PRO5 --> ROUTE1
       end
-      
-      subgraph subID2[**Metrics**]
-      direction LR
-      ROUTE1 --> ROUTE3
-      ROUTE3 --> PRO2       
-      ROUTE2 --> PRO2
-      REC3 --> PRO2
-      PRO2 --> PRO8
-      PRO8 --> PRO4
-      PRO4 --> PRO6
-      PRO6 --> EXP3
-      PRO6 --> EXP4
+
+      subgraph subID2["`**Metrics**`"]
+        direction LR
+        ROUTE1 --> ROUTE3
+        ROUTE3 --> PRO2
+        ROUTE2 --> PRO2
+        REC3 --> PRO2
+        PRO2 --> PRO8
+        PRO8 --> PRO4
+        PRO4 --> PRO6
+        PRO6 --> EXP3
+        PRO6 --> EXP4
       end
     end
+    class subID1 sub-traces
+    class subID2 sub-metrics
+
 classDef receiver,exporter fill:#8b5cf6,stroke:#333,stroke-width:1px,color:#fff;
 classDef processor fill:#6366f1,stroke:#333,stroke-width:1px,color:#fff;
 classDef con-receive,con-export fill:#45c175,stroke:#333,stroke-width:1px,color:#fff;
-classDef sub-logs stroke:#34d399,stroke-width:1px, color:#34d399,stroke-dasharray: 3 3;
-classDef sub-traces stroke:#fbbf24,stroke-width:1px, color:#fbbf24,stroke-dasharray: 3 3;
-classDef sub-metrics stroke:#38bdf8,stroke-width:1px, color:#38bdf8,stroke-dasharray: 3 3;
+classDef sub-logs stroke:#34d399,stroke-width:1px,color:#34d399,stroke-dasharray: 3 3;
+classDef sub-traces stroke:#fbbf24,stroke-width:1px,color:#fbbf24,stroke-dasharray: 3 3;
+classDef sub-metrics stroke:#38bdf8,stroke-width:1px,color:#38bdf8,stroke-dasharray: 3 3;
 ```
 
 {{% /notice %}}

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/_index.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/_index.md
@@ -170,7 +170,7 @@ graph LR
       PRO5 --> EXP2
       end
       
-      subgraph subID2[**Metrics**]
+      subgraph subID2["`**Metrics**`"]
       direction LR
       ROUTE1 --> ROUTE2       
       ROUTE2 --> PRO2

--- a/content/en/splunk4rookies/observability-cloud-short/6-synthetics/5-create-detector.md
+++ b/content/en/splunk4rookies/observability-cloud-short/6-synthetics/5-create-detector.md
@@ -17,7 +17,7 @@ weight: 5
 
 > [!WARNING] We will not add a recipient or activate the detector as we don't want to flood your email with alerts.
 
-{{% image src="../images/synth-detector.png" align="center" %}}
+![Detector](../images/synth-detector.png)
 
 * This application is designed to fail constantly, hence the large number of alerts that would be generated. In a real-world scenario, you would want to fine-tune the threshold to avoid false positives.
 

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/2-building-resilience/2-1-configuration.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/2-building-resilience/2-1-configuration.md
@@ -83,7 +83,7 @@ graph LR
     %% Links
     subID1:::sub-metrics
     subgraph " "
-      subgraph subID1[**Metrics**]
+      subgraph subID1["`**Metrics**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO2

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/3-dropping-spans/3-1-configuration.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/3-dropping-spans/3-1-configuration.md
@@ -56,7 +56,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PRO4

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/4-sensitive-data/4-1-configuration.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/4-sensitive-data/4-1-configuration.md
@@ -102,7 +102,7 @@ graph LR
     %% Links
     subID1:::sub-traces
     subgraph " "
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRML
       PRML --> PRUP

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/6-routing-data/6-2-pipelines.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/6-routing-data/6-2-pipelines.md
@@ -80,7 +80,7 @@ graph LR
     subID3:::sub-traces
     subgraph " "
     direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       REC1 --> ROUTE1
       end
       subgraph subID2[**Traces/route2-security**]

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/7-2-sum.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/7-2-sum.md
@@ -120,7 +120,7 @@ graph LR
     subID2:::sub-metrics
     subgraph " "
       direction LR
-      subgraph subID1[**Traces**]
+      subgraph subID1["`**Traces**`"]
       direction LR
       REC1 --> PRO1
       PRO1 --> PROA
@@ -134,7 +134,7 @@ graph LR
       PRO5 --> ROUTE1
       end
 
-      subgraph subID2[**Metrics**]
+      subgraph subID2["`**Metrics**`"]
       direction LR
       ROUTE1 --> ROUTE3
       ROUTE3 --> PRO2

--- a/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/_index.md
+++ b/content/ja/ninja-workshops/3-opentelemetry-collector-workshops/2-advanced-collector/7-sum-count/_index.md
@@ -170,7 +170,7 @@ graph LR
       PRO5 --> EXP2
       end
 
-      subgraph subID2[**Metrics**]
+      subgraph subID2["`**Metrics**`"]
       direction LR
       ROUTE1 --> ROUTE2
       ROUTE2 --> PRO2

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.10.4 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.10.6 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,7 @@ github.com/splunk/hugo-theme-splunk-workshop v0.10.4-0.20260526114556-c5b54ff2f3
 github.com/splunk/hugo-theme-splunk-workshop v0.10.4-0.20260526114556-c5b54ff2f342/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
 github.com/splunk/hugo-theme-splunk-workshop v0.10.4 h1:+JAXBswF/55lisSvd6zkXkeMNPoakE3bbZAq2awq8Zs=
 github.com/splunk/hugo-theme-splunk-workshop v0.10.4/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.10.5 h1:7IT8AQiMM3yrrdSKrahlpZonXvlBHr1YRAYhRRQcleI=
+github.com/splunk/hugo-theme-splunk-workshop v0.10.5/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.10.6 h1:uBEcRLTOwVqKbhksowg1cYI0OMhpLn1r18bzvukpkrI=
+github.com/splunk/hugo-theme-splunk-workshop v0.10.6/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=

--- a/hugo.toml
+++ b/hugo.toml
@@ -134,7 +134,7 @@ disableKinds = ["taxonomy", "term"]
   showToc         = true
   showProgress    = true
   showLightTrails = true
-  contentMaxWidth = "720px"
+  contentMaxWidth = "880px"
 
   # ---- Repo / edit-on-github --------------------------------------------
   editURL = ""


### PR DESCRIPTION
- Bump hugo-theme-splunk-workshop v0.10.4 -> v0.10.6 (go.mod, go.sum, assets/jsconfig.json IntelliSense path).
- Widen `contentMaxWidth` from 720px to 880px in hugo.toml.
- Drop the legacy 404 redirect handler step from the deploy workflow.
- Fix Mermaid subgraph bold-label syntax (`[**Metrics**]` -> ``["`**Metrics**`"]``) across the advanced-collector pages in both `content/en/` and `content/ja/`.
- Switch the detector image in the 1h synthetics workshop to plain markdown so the path resolves at the browser instead of failing the theme's bundle lookup.

