### PR TITLE
Theme v0.11.0, themed 404 fallback, Browse Workshops landing

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -88,6 +88,16 @@ jobs:
         run: |
           hugo --minify --destination "public" --baseURL "${{ steps.bumpversion.outputs.base_url }}observability-workshop" --noChmod --cacheDir /tmp/hugo_cache
 
+      - name: Promote themed 404 to repo root
+        # `defaultContentLanguageInSubdir = true` makes Hugo emit /en/404.html
+        # and /ja/404.html but no language-neutral /404.html. GitHub Pages only
+        # serves the catch-all from the repo root, so without this copy a
+        # bookmarked /repo/en/foo (or /repo/latest/en/foo) hits GitHub's plain
+        # text/plain 404 instead of the themed page. Assets in the EN 404 are
+        # already absolute (/<repo>/css/…) so the copied page renders fine
+        # from the root.
+        run: cp public/en/404.html public/404.html
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../go/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.10.10/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.11.0/assets/*"
    ]
   }
  }

--- a/content/en/browse/_index.md
+++ b/content/en/browse/_index.md
@@ -1,0 +1,10 @@
+---
+title: Browse *Workshops*
+linkTitle: Browse Workshops
+description: Every workshop in one place.
+layout: browse
+weight: 5
+menu:
+  main:
+    weight: 5
+---q

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
@@ -5,7 +5,7 @@ archetype: chapter
 time: 5 minutes
 ---
 
-### Prerequisites
+## Prerequisites
 
 - Proficiency in editing YAML files using `vi`, `vim`, `nano`, or your preferred text editor.
 - Supported Environments:
@@ -14,7 +14,9 @@ time: 5 minutes
 
 {{% exercise title="Create the workshop directory" %}}
 
-**Create a directory**: In your environment create a new directory and change into it:
+{{< step "Initial Setup" "1" >}}
+
+In your environment create a new directory and change into it:
 
 ``` bash
 mkdir advanced-otel-workshop && \
@@ -37,8 +39,11 @@ kubectl delete ~/workshop/apm/deployment.yaml
 ```
 
 {{% /notice %}}
+{{< /step >}}
 
-**Download workshop binaries**: Change into your `[WORKSHOP]` directory and download the OpenTelemetry Collector, Load Generator binaries and setup script:
+{{< step "Download workshop binaries" "2" >}}
+
+Change into your `[WORKSHOP]` directory and download the OpenTelemetry Collector, Load Generator binaries and setup script:
 
 {{% tabs %}}
 {{% tab title="Splunk Workshop Instance" %}}
@@ -60,33 +65,12 @@ curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/wor
 chmod +x setup-workshop.sh
 ```
 
-<!--
-{{% notice style="warning" title="macOS Users" icon="desktop" %}}
-Before running the binaries on macOS, you need to remove the quarantine attribute that macOS applies to downloaded files. This step ensures they can execute without restrictions.
-
-Run the following command in your terminal:
-
-```bash { title="Remove Quarantine Attribute"}
-xattr -dr com.apple.quarantine otelcol && \
-xattr -dr com.apple.quarantine loadgen
-```
-
-{{% /notice %}}
--->
 {{% /tab %}}
 {{% /tabs %}}
 
-<!--
-**Update file permissions**: Once downloaded, update the file permissions to make all files executable:
+{{< /step >}}
 
-```bash
-chmod +x otelcol loadgen setup-workshop.sh && \
-./otelcol -v && \
-./loadgen --help && \
-./setup-workshop.sh
-```
--->
-
+{{< step "Run the setup" "3" >}}
 Run the `setup-workshop.sh` script which will configure the correct permissions and also create the initial configurations for the **Agent** and the **Gateway**:
 
 {{% tabs %}}
@@ -184,9 +168,8 @@ Configuration files created in the following directories:
 └── setup-workshop.sh
 ```
 
-<!--
-{{% notice note %}}
-Having access to [**jq**](https://jqlang.org/download/) is recommended (installed by default on Splunk workshop instances). This lightweight command-line tool helps process and format JSON data, making it easier to inspect traces, metrics, and logs from the OpenTelemetry Collector.
-{{% /notice %}}
--->
+{{< /step >}}
+
 {{% /exercise %}}
+
+{{< checkpoint "Workshop environment is ready — onto **Chapter 1: Agent Configuration**." >}}

--- a/content/ja/browse/_index.md
+++ b/content/ja/browse/_index.md
@@ -1,0 +1,10 @@
+---
+title: Browse *Workshops*
+linkTitle: Browse Workshops
+description: Every workshop in one place.
+layout: browse
+weight: 5
+menu:
+  main:
+    weight: 5
+---

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.10.10 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.11.0 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/splunk/hugo-theme-splunk-workshop v0.10.9 h1:BimhaM7o+MMOxkblJQOVqqTu
 github.com/splunk/hugo-theme-splunk-workshop v0.10.9/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
 github.com/splunk/hugo-theme-splunk-workshop v0.10.10 h1:DSh7v89CIZaOADD3kSr4fU9oHkJLvWu7OWry7lhVK18=
 github.com/splunk/hugo-theme-splunk-workshop v0.10.10/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.0 h1:B8KTrX3gT2jlfZbXhAUYrr6lYxHh6Oz6j9MxctEpWWQ=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.0/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=

--- a/hugo.toml
+++ b/hugo.toml
@@ -67,6 +67,15 @@ disableKinds = ["taxonomy", "term"]
 # Drop these in your own site's hugo.toml to rebrand the theme entirely.
 # ==========================================================================
 [params]
+  # ---- Legacy URL handling -----------------------------------------------
+  # Older deployments of this site used a `/latest/` segment in the URL
+  # (e.g. /observability-workshop/latest/en/workshop-setup/). External
+  # bookmarks and search results still point there. With this flag set, the
+  # theme's 404 page rewrites `/…/latest/<rest>` to `/…/<rest>` on the fly
+  # so legacy URLs land on the canonical page instead of GitHub's plain 404.
+  # Set to false (or remove) once you're confident no `/latest/` links remain.
+  legacyLatestRedirect = true
+
   # ---- Identity ----------------------------------------------------------
   brandName       = "splunk>"
   brandTagline    = ""           # set to "" to suppress the "splunk> | workshops" tag pill


### PR DESCRIPTION
* Bump hugo-theme-splunk-workshop v0.10.10 -> v0.11.0 (go.mod, go.sum, assets/jsconfig.json IntelliSense path back to the Library/Caches module cache).
* Add a "Promote themed 404 to repo root" step to the deploy workflow. `defaultContentLanguageInSubdir = true` makes Hugo emit /en/404.html but no root /404.html, so GitHub Pages was serving its plain-text catch-all for unknown URLs. Copy the EN 404 to /404.html post-build.
* Enable the theme's `legacyLatestRedirect` param in hugo.toml so the themed 404 rewrites legacy `/repo/latest/<rest>` bookmarks to the current canonical path on the fly.
* Add a "Browse Workshops" landing page (en + ja) using the theme's `browse` layout.
* Restructure 2-advanced-collector/prerequisites.md into three numbered steps (Initial Setup, Download workshop binaries, Run the setup) inside the existing exercise; also promote the page heading from `### Prerequisites` to `## Prerequisites` so it appears in the TOC at the right level.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

