### PR TITLE
Reshape PR template for content work; theme bump to v0.11.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,44 @@
-# Pull Request Template
+## Summary
 
-## Description
+What this PR changes and why. One or two sentences.
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Fixes # (optional — link an issue / ticket)
 
-Fixes # (issue)
+## Type of change
 
-### Type of change
+- [ ] New workshop
+- [ ] New chapter or page in an existing workshop
+- [ ] Content edits (clarity, correctness, polish) to existing pages
+- [ ] Restructure / reorganize (move, split, merge, renumber)
+- [ ] URL change — `aliases:` added for any renamed or moved page
+- [ ] Image / screenshot refresh
+- [ ] Translation sync (`content/en` ↔ `content/ja`)
+- [ ] Content removal / archival
+- [ ] Theme bump or shortcode / layout adoption
+- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
+- [ ] Lint / formatting cleanup (low-risk, scan-approve)
+- [ ] CI / build / tooling
+- [ ] Bug fix (broken link, busted shortcode, etc.)
+- [ ] Other — describe:
 
-Please delete options that are not relevant.
+## What's affected
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- **Workshop(s) / area:** e.g. `splunk4rookies/observability-cloud-short/`, `ninja-workshops/foundations/3-opentelemetry-collector-workshops/`
+- **Languages:** [ ] `content/en` &nbsp;&nbsp; [ ] `content/ja`
 
-## How Has This Been Tested?
+## Reviewer focus
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+Anything you'd specifically like the reviewer to check? (e.g. "verify the `kubectl` command in step 3 against the current OTel collector"). Leave blank if not applicable.
 
-- [ ] Test A
-- [ ] Test B
+## Screenshots / preview
 
-## Checklist
+For visual changes, paste a before/after screenshot or a Hugo preview link.
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] Markdown Lint passes locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
+## Verification
+
+- [ ] `hugo` builds cleanly (no warnings or errors)
+- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
+- [ ] Any new images have meaningful alt text
+- [ ] No TODO image placeholders left unintentionally
+- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
+- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.11.0 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.11.2 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.10.8 h1:Y2+4KCWKDqUXmEk9Hp8MtnJYZK+aKa0b3j6iHGyDDEc=
-github.com/splunk/hugo-theme-splunk-workshop v0.10.8/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.10.9 h1:BimhaM7o+MMOxkblJQOVqqTuNLZCdtnxcmdC7CB3rBo=
-github.com/splunk/hugo-theme-splunk-workshop v0.10.9/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.10.10 h1:DSh7v89CIZaOADD3kSr4fU9oHkJLvWu7OWry7lhVK18=
-github.com/splunk/hugo-theme-splunk-workshop v0.10.10/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.0 h1:B8KTrX3gT2jlfZbXhAUYrr6lYxHh6Oz6j9MxctEpWWQ=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.0/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.2 h1:6cWtrqiGKt4NDFlM+wIw0E6FcnCXWQ4PXNFCMlXwS/I=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.2/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
* Rewrite .github/pull_request_template.md to match how this repo actually changes — drops the dev-shaped "bug fix vs feature vs breaking change" categories and "self-review of my own code" checklist in favour of content lifecycle categories (new workshop, new chapter/page, edits, restructure, URL/aliases, screenshot refresh, translation sync, removal, theme bump, frontmatter-only, lint cleanup, CI, bug fix). Adds a Reviewer-focus prompt, an alias/URL safety check, and a parallel/sibling-workshop ripple check to the verification list.
* Bump hugo-theme-splunk-workshop v0.11.0 -> v0.11.2 (go.mod, go.sum pruned to the single current entry by `go mod tidy`).
