### PR TITLE
updated agentic AI workshop to use LiteLLM proxy instead of Azure OpenAI

### DIFF
--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-7-llm-creation.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-7-llm-creation.md
@@ -9,6 +9,36 @@ weight: 7
 The LLM itself is created here:
 
 ```python
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
+
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
+
+    return ChatOpenAI(
+        model = model_name,
+        temperature = temperature,
+        # Uses OPENAI_API_KEY automatically from environment
+    )
+```
+
+This approach separates model configuration from workflow logic.
+Different nodes can use different temperatures depending on how deterministic or
+creative they should be.
+
+### Knowledge Check
+
+How would you create an LLM for Azure OpenAI (rather than OpenAI?)
+
+<details>
+  <summary><b>Click here to see the answer</b></summary>
+
+Creating an LLM for Azure OpenAI has a few differences. The function would return a `AzureChatOpenAI` 
+object instead of `ChatOpenAI`. 
+
+The solution would also require Azure-specific parameters (`azure_deployment`, 
+`openai_api_version`, `Azure endpoint`). Here's an example: 
+
+```python
 def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
     azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
     azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
@@ -19,37 +49,6 @@ def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> Azur
         temperature=temperature,
         model_name = azure_deployment_name,
         # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
-    )
-```
-
-This approach separates model configuration from workflow logic.
-Different nodes can use different temperatures depending on how deterministic or
-creative they should be.
-
-### Knowledge Check
-
-How would you create an LLM for OpenAI (rather than Azure OpenAI?)
-
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
-Creating an LLM for OpenAI has a few differences. The function would return a `ChatOpenAI` 
-object instead of `AzureChatOpenAI`. 
-
-With OpenAI directly, you don’t use the Azure-specific parameters (`azure_deployment`, 
-`openai_api_version`, `Azure endpoint`). Instead, you specify the model name and rely 
-on the standard `OPENAI_API_KEY` environment variable.
-
-Here's an example: 
-
-```python
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
-    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
-
-    return ChatOpenAI(
-        model=model_name,
-        temperature=temperature,
-        # Uses OPENAI_API_KEY automatically from environment
     )
 ```
 

--- a/content/en/ninja-workshops/ai/18-agentic-ai/5-deploy-the-app.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/5-deploy-the-app.md
@@ -14,13 +14,11 @@ We'll start by running the application directly on our Linux EC2 instance.
 The document provided by the workshop instructor contains `export` commands to set the following 
 environment variables: 
 
-* `AZURE_OPENAI_DEPLOYMENT_NAME`
-* `AZURE_OPENAI_API_VERSION`
-* `AZURE_OPENAI_ENDPOINT`
-* `AZURE_OPENAI_API_KEY`
+* `OPENAI_API_KEY`
+* `OPENAI_BASE_URL`
 
 These environment variables tell the application how to connect to an 
-OpenAI model hosted in Azure. 
+OpenAI model hosted in Azure (via Lite LLM Proxy). 
 
 Copy and paste these `export` commands from the document and run them in your ssh terminal.
 
@@ -106,22 +104,22 @@ Let's create a new namespace to host our application:
 kubectl create ns travel-agent
 ```
 
-### Create Secret with Azure Credentials
+### Create Secret with the OpenAI Credentials
 
-We'll use a Kubernetes secret to store the Azure OpenAI endpoint and key:
+We'll use a Kubernetes secret to store the OpenAI endpoint and key:
 
 > Caution: ensure you run this command in the terminal where you set 
-> the `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_KEY` environment 
+> the `OPENAI_API_KEY` and `OPENAI_BASE_URL` environment 
 > variables earlier. 
 
 ``` bash
-{ [ -z "$AZURE_OPENAI_ENDPOINT" ] || \
-  [ -z "$AZURE_OPENAI_API_KEY" ]; } && \
+{ [ -z "$OPENAI_API_KEY" ] || \
+  [ -z "$OPENAI_BASE_URL" ]; } && \
   echo "Error: Missing variables" || \
-  kubectl create secret generic azure-openai-api \
+  kubectl create secret generic openai-api \
   -n travel-agent \
-  --from-literal=azure-openai-api-endpoint=$AZURE_OPENAI_ENDPOINT \
-  --from-literal=azure-openai-api-key=$AZURE_OPENAI_API_KEY
+  --from-literal=openai-api-endpoint=$OPENAI_BASE_URL \
+  --from-literal=openai-api-key=$OPENAI_API_KEY
 ```
 
 > Note: if you get an error that says Missing variables, you’ll need to 

--- a/workshop/agentic-ai/app-with-agents-and-tools/k8s.yaml
+++ b/workshop/agentic-ai/app-with-agents-and-tools/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
             # Service Name

--- a/workshop/agentic-ai/app-with-agents-and-tools/main.py
+++ b/workshop/agentic-ai/app-with-agents-and-tools/main.py
@@ -41,7 +41,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -161,19 +161,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 

--- a/workshop/agentic-ai/app-with-ai-defense/k8s.yaml
+++ b/workshop/agentic-ai/app-with-ai-defense/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
             # Service Name

--- a/workshop/agentic-ai/app-with-ai-defense/main.py
+++ b/workshop/agentic-ai/app-with-ai-defense/main.py
@@ -52,7 +52,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -173,19 +173,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 

--- a/workshop/agentic-ai/app-with-instrumentation/k8s.yaml
+++ b/workshop/agentic-ai/app-with-instrumentation/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
             # Service Name

--- a/workshop/agentic-ai/app-with-instrumentation/main.py
+++ b/workshop/agentic-ai/app-with-instrumentation/main.py
@@ -41,7 +41,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -119,19 +119,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 

--- a/workshop/agentic-ai/app-with-quality-issue/k8s.yaml
+++ b/workshop/agentic-ai/app-with-quality-issue/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
             # Service Name

--- a/workshop/agentic-ai/app-with-quality-issue/main.py
+++ b/workshop/agentic-ai/app-with-quality-issue/main.py
@@ -41,7 +41,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -162,19 +162,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 

--- a/workshop/agentic-ai/app-with-security-risk/k8s.yaml
+++ b/workshop/agentic-ai/app-with-security-risk/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
             # Service Name

--- a/workshop/agentic-ai/app-with-security-risk/main.py
+++ b/workshop/agentic-ai/app-with-security-risk/main.py
@@ -52,7 +52,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -173,19 +173,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 

--- a/workshop/agentic-ai/base-app/k8s.yaml
+++ b/workshop/agentic-ai/base-app/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_OPENAI_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_OPENAI_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Begin: Add Environment Variables
 

--- a/workshop/agentic-ai/base-app/main.py
+++ b/workshop/agentic-ai/base-app/main.py
@@ -41,7 +41,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import AnyMessage, add_messages
 
@@ -97,7 +97,6 @@ def _compute_dates() -> tuple[str, str]:
 
 # End: Tool Definitions
 
-
 # ---------------------------------------------------------------------------
 # LangGraph state & helpers
 # ---------------------------------------------------------------------------
@@ -120,19 +119,15 @@ class PlannerState(TypedDict):
     final_itinerary: Optional[str]
     current_agent: str
 
-def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> AzureChatOpenAI:
-    """Create an AzureChatOpenAI instance."""
+def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> ChatOpenAI:
+    """Create an ChatOpenAI instance."""
 
-    azure_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+    model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4.1-mini")
 
-    # Azure OpenAI Configuration
-    return AzureChatOpenAI(
-        azure_deployment = azure_deployment_name,
-        openai_api_version = azure_openai_api_version,
+    return ChatOpenAI(
+        model = model_name,
         temperature = temperature,
-        model_name = azure_deployment_name,
-        # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
+        # Uses OPENAI_API_KEY and OPENAI_BASE_URL automatically from environment
     )
 
 
@@ -307,6 +302,7 @@ def plan_synthesizer_node(state: PlannerState) -> PlannerState:
     llm = _create_llm(
         "plan_synthesizer", temperature=0.3, session_id=state["session_id"]
     )
+
     system_content = (
         "You are the travel plan synthesiser. Combine the specialist insights into a "
         "concise, structured itinerary covering flights, accommodation and activities."

--- a/workshop/agentic-ai/crewai/crew_runner.py
+++ b/workshop/agentic-ai/crewai/crew_runner.py
@@ -17,30 +17,29 @@ def _load_yaml(path: str) -> dict:
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
-def _azure_model_name() -> str:
-    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+def _openai_model_name() -> str:
+    deployment = os.getenv("OPENAI_MODEL_NAME")
     if not deployment:
-        raise RuntimeError("Missing AZURE_OPENAI_DEPLOYMENT_NAME")
-    return f"azure/{deployment}"
+        raise RuntimeError("Missing OPENAI_MODEL_NAME")
+    return deployment
 
 
-def _validate_azure_env() -> None:
+def _validate_openai_env() -> None:
     required = [
-        "AZURE_API_KEY",
-        "AZURE_ENDPOINT",
-        "AZURE_OPENAI_API_VERSION",
-        "AZURE_OPENAI_DEPLOYMENT_NAME",
+        "OPENAI_BASE_URL",
+        "OPENAI_MODEL_NAME",
+        "OPENAI_API_KEY",
     ]
     missing = [k for k in required if not os.getenv(k)]
     if missing:
-        raise RuntimeError(f"Missing Azure env vars: {', '.join(missing)}")
+        raise RuntimeError(f"Missing OpenAI env vars: {', '.join(missing)}")
 
 
 def build_crew() -> Crew:
-    _validate_azure_env()
+    _validate_openai_env()
     agents_cfg = _load_yaml("config/agents.yaml")
     tasks_cfg = _load_yaml("config/tasks.yaml")
-    model = _azure_model_name()
+    model = _openai_model_name()
 
     coordinator = Agent(
         config=agents_cfg["coordinator"],

--- a/workshop/agentic-ai/crewai/k8s.yaml
+++ b/workshop/agentic-ai/crewai/k8s.yaml
@@ -23,22 +23,18 @@ spec:
             - containerPort: 8080
               name: http
           env:
-            - name: AZURE_OPENAI_DEPLOYMENT_NAME
-              value: "gpt-4.1-mini"
-            - name: AZURE_ENDPOINT
+            - name: OPENAI_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-endpoint
-            - name: AZURE_OPENAI_API_VERSION
-              value: "2024-12-01-preview"
-            - name: AZURE_API_KEY
+                  name: openai-api
+                  key: openai-api-endpoint
+            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-openai-api
-                  key: azure-openai-api-key
+                  name: openai-api
+                  key: openai-api-key
             # OpenAI Model
-            - name: OPENAI_MODEL
+            - name: OPENAI_MODEL_NAME
               value: "gpt-4.1-mini"
             # Service Name
             - name: OTEL_SERVICE_NAME


### PR DESCRIPTION
This PR modifies the agentic AI workshop so it can use the LiteLLM proxy instead of OpenAI. This required changes to environment variables used by the demo app, and code changes to use the OpenAI API rather than Azure OpenAI. 