### PR TITLE
Update 1-otel-collector.md to remove --without-fluentd flag, improve …

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith/1-otel-collector.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith/1-otel-collector.md
@@ -4,7 +4,7 @@ linkTitle: 1. OpenTelemetry Collector
 weight: 1
 ---
 
-The Splunk OpenTelemetry Collector is the core component of instrumenting infrastructure and applications.  Its role is to collect and send:
+The Splunk OpenTelemetry Collector is the core component for instrumenting infrastructure and applications.  Its role is to collect and send:
 
 * Infrastructure metrics (disk, CPU, memory, etc.)
 * Application Performance Monitoring (APM) traces
@@ -18,7 +18,7 @@ If you have completed the Splunk IM workshop, please ensure you have deleted the
 helm delete splunk-otel-collector
 ```
 
-The EC2 instance may already have an older version of the collector already installed. To uninstall the collector, run the following commands:
+The EC2 instance may already have an older version of the collector installed. To uninstall the collector, run the following commands:
 
 ``` bash
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh
@@ -27,13 +27,13 @@ sudo sh /tmp/splunk-otel-collector.sh --uninstall
 
 {{% /notice %}}
 
-To ensure your instance is configured correctly, we need to confirm that the required environment variables for this workshop are set correctly. In your terminal run the following command:
+To ensure your instance is configured correctly, we need to confirm that the required environment variables for this workshop are set correctly. In your terminal, run the following command:
 
 ``` bash
 . ~/workshop/petclinic/scripts/check_env.sh
 ```
 
-In the output check that all the following environment variables are present and have values set. If any are missing, please contact your instructor:
+In the output, check that all the following environment variables are present and have values set. If any are missing, please contact your instructor:
 
 ```text
 ACCESS_TOKEN
@@ -44,19 +44,19 @@ HEC_URL
 INSTANCE
 ```
 
-We can then go ahead and install the Collector. Some additional parameters are passed to the installation script, they are:
+You can then install the Collector. Some additional parameters are passed to the installation script:
 
 * `--with-instrumentation` - This will install the agent from the Splunk distribution of OpenTelemetry Java, which is then loaded automatically when the PetClinic Java application starts up. No configuration is required!
 * `--deployment-environment` - Sets the resource attribute `deployment.environment` to the value passed. This is used to filter views in the UI.
 * `--enable-profiler` - Enables the profiler for the Java application. This will generate CPU profiles for the application.
 * `--enable-profiler-memory` - Enables the profiler for the Java application. This will generate memory profiles for the application.
-* `--enable-metrics` - Enables the exporting of Micrometer metrics
-* `--hec-token` - Sets the HEC token for the collector to use
-* `--hec-url` - Sets the HEC URL for the collector to use
+* `--enable-metrics` - Enables the exporting of Micrometer metrics.
+* `--hec-token` - Sets the HEC token for the collector to use.
+* `--hec-url` - Sets the HEC URL for the collector to use.
 
 ``` bash
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
-sudo sh /tmp/splunk-otel-collector.sh --realm $REALM -- $ACCESS_TOKEN --mode agent --without-fluentd --with-instrumentation --deployment-environment $INSTANCE-petclinic --enable-profiler --enable-profiler-memory --enable-metrics --hec-token $HEC_TOKEN --hec-url $HEC_URL
+sudo sh /tmp/splunk-otel-collector.sh --realm $REALM -- $ACCESS_TOKEN --mode agent --with-instrumentation --deployment-environment $INSTANCE-petclinic --enable-profiler --enable-profiler-memory --enable-metrics --hec-token $HEC_TOKEN --hec-url $HEC_URL
 ```
 
 Next, we will patch the collector to expose the hostname of the instance and not the AWS instance ID. This will make it easier to filter data in the UI:
@@ -71,6 +71,6 @@ Once the `agent_config.yaml` has been patched, you will need to restart the coll
 sudo systemctl restart splunk-otel-collector
 ```
 
-Once the installation is completed, you can navigate to the **Hosts with agent installed** dashboard to see the data from your host, **Dashboards → Hosts with agent installed**.
+Once the installation is complete, you can navigate to the **Hosts with agent installed** dashboard to see the data from your host, **Dashboards → Hosts with agent installed**.
 
-Use the dashboard filter and select `host.name` and type or select the hostname of your workshop instance (you can get this from the command prompt in your terminal session). Once you see data flowing for your host, we are then ready to get started with the APM component.
+Click inside the 'Host' field in the filter panel and then type or select the hostname of your workshop instance (you can get this from the command prompt in your terminal session). Once you see data flowing for your host, you are then ready to get started with the APM component.


### PR DESCRIPTION
…readability

--without-fluentd is breaking Collector installation with current versions of the Collector.

## Summary

What this PR changes and why. One or two sentences.

Fixes # (optional — link an issue / ticket)

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X ] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ X] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:**  `ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith`
- **Languages:** [X ] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus

Anything you'd specifically like the reviewer to check? (e.g. "verify the `kubectl` command in step 3 against the current OTel collector"). Leave blank if not applicable.

## Screenshots / preview

For visual changes, paste a before/after screenshot or a Hugo preview link.

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
