### PR TITLE
Update 2-building-petclinic.md readability

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith/2-building-petclinic.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith/2-building-petclinic.md
@@ -4,9 +4,9 @@ linkTitle: 2. Building PetClinic
 weight: 2
 ---
 
-The first thing we need to set up APM is... well, an application. For this exercise, we will use the Spring PetClinic application. This is a very popular sample Java application built with the Spring framework (Springboot).
+The first thing we need to set up APM is... well, an application. For this exercise, we will use the Spring PetClinic application. This is a very popular sample Java application built with the Spring framework (via Spring Boot).
 
-First, clone the PetClinic GitHub repository, and then we will compile, build, package and test the application:
+First, clone the Spring PetClinic GitHub repository. Later, we will compile, build, package and test the application:
 
 ```bash
 git clone https://github.com/spring-projects/spring-petclinic
@@ -31,20 +31,20 @@ Using Docker, start a MySQL database for PetClinic to use:
 docker run -d -e MYSQL_USER=petclinic -e MYSQL_PASSWORD=petclinic -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=petclinic -p 3306:3306 docker.io/biarms/mysql:5.7
 ```
 
-Next, we will start another container running Locust that will generate some simple traffic to the PetClinic application. Locust is a simple load-testing tool that can be used to generate traffic to a web application.
+Next, we will start another container running Locust that will generate some traffic in the Spring PetClinic application. Locust is a simple load-testing tool.
 
 ```bash
 docker run --network="host" -d -p 8090:8090 -v ~/workshop/petclinic:/mnt/locust docker.io/locustio/locust -f /mnt/locust/locustfile.py --headless -u 1 -r 1 -H http://127.0.0.1:8083
 ```
 
-Next, compile, build and package PetClinic using `maven`:
+Next, compile, build and package the application using `maven`:
 
 ```bash
 ./mvnw package -Dmaven.test.skip=true
 ```
 
 > [!INFO]
-> This will take a few minutes the first time you run and will download a lot of dependencies before it compiles the application. Future builds will be a lot quicker.
+> This command will take a few minutes to complete the first time, because it downloads a lot of dependencies before compiling the application. Future builds will be much quicker.
 
 Once the build completes, you need to obtain the public IP address of the instance you are running on. You can do this by running the following command:
 
@@ -52,4 +52,4 @@ Once the build completes, you need to obtain the public IP address of the instan
 curl http://ifconfig.me
 ```
 
-You will see an IP address returned, make a note of this as we will need it to validate that the application is running.
+Make a note of the IP address returned by this command, as we will need it to validate that the application is running.


### PR DESCRIPTION
Fixed incorrect reference to Spring Boot, characterization of Spring/Spring Boot relationship, improved readability throughout.

## Summary

Fixed incorrect reference to Spring Boot, characterization of Spring/Spring Boot relationship, improved readability throughout.

Fixes # (optional — link an issue / ticket)

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X ] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:**  `ninja-workshops/foundations/1-automatic-discovery/1-petclinic-monolith`
- **Languages:** [X ] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
