### PR TITLE
Update 1-patching-deployment.md

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/4-apm/1-patching-deployment.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/4-apm/1-patching-deployment.md
@@ -4,7 +4,7 @@ linkTitle: 1. Patching the Deployment
 weight: 1
 ---
 
-To configure **automatic discovery and configuration**, the deployments need to be patched to add the instrumentation annotation. Once patched, the OpenTelemetry Collector will inject the automatic discovery and configuration library and the Pods will be restarted in order to start sending traces and profiling data. First, confirm that the `api-gateway` does not have the `splunk-otel-java` image by running the following:
+To configure **automatic discovery and configuration**, the deployments need to be patched to add the instrumentation annotation. Once patched, the OpenTelemetry Collector will inject the automatic discovery and configuration library and the Pods will be restarted in order to start sending traces and profiling data. First, confirm that the `api-gateway` does not already contain the `splunk-otel-java` image by running the following:
 
 {{< tabs >}}
 {P}{{% tab title="Describe api-gateway" %}}
@@ -23,7 +23,7 @@ Image:         quay.io/phagen/spring-petclinic-api-gateway:0.0.2
 {{% /tab %}}
 {{< /tabs >}}
 
-Next, enable the Java automatic discovery and configuration for all the services by adding the annotation to the deployments. The following command will patch the all deployments. This will trigger the OpenTelemetry Operator to inject the `splunk-otel-java` image into the Pods:
+Next, enable Java automatic discovery and configuration for all the services by adding the annotation to the deployments. The following command will patch all the deployments. This will trigger the OpenTelemetry Operator to inject the `splunk-otel-java` image into the Pods:
 
 {{< tabs >}}
 {{% tab title="Patch all PetClinic services" %}}
@@ -76,4 +76,4 @@ Navigate back to the Kubernetes Navigator in **Splunk Observability Cloud**. Aft
 
 ![restart](../../images/k8s-navigator-restarted-pods.png)
 
-Wait for the Pods to turn green in the Kubernetes Navigator, then go tho the next section.
+Wait for the Pods to turn green in the Kubernetes Navigator, then proceed to the next section.


### PR DESCRIPTION
## Summary

Fix a couple typos, minor edits for readability.

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X ] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:**  `ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/4-apm/1-patching-deployment/`
- **Languages:** [X ] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
