### PR TITLE
Update 4-red-metrics.md

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/4-red-metrics.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/4-red-metrics.md
@@ -6,7 +6,7 @@ weight: 4
 
 Splunk APM provide **Service Centric Views** that provide engineers a deep understanding of service performance in one centralized view. Now, across every service, engineers can quickly identify errors or bottlenecks from a service’s underlying infrastructure, pinpoint performance degradation from new deployments, and visualize the health of every third party dependency.
 
-To see this dashboard for the `api-gateway`, click on **APM** from the left-hand menu and then click on the `api-gateway` service in the list. This will bring you to the Service Centric View dashboard:
+To see this dashboard for the `api-gateway`, click on **APM → Overview** from the left-hand menu, click in the 'Navigate to a service, business transaction, or trace' field, and then select the `api-gateway` service in the drop-down list. This will bring you to the Service Centric View dashboard:
 
 ![service_maps](../../images/service-view.png)
 


### PR DESCRIPTION
## Summary

Update navigation directions to reflect updated UX. Add instruction to first click into the service selection field. Clarified the service is selected from a drop-down list.


## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:**  `ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/4-red-metrics/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
