### PR TITLE
Update _index.md

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/9-wrap-up/_index.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/9-wrap-up/_index.md
@@ -3,12 +3,12 @@ title: Workshop Wrap-up 🎁
 linkTitle: 9. Workshop Wrap-up
 weight: 9
 archetype: chapter
-description: Congratulations, you have completed the Get the Most Out of Your Existing Kubernetes Java Applications Using Automatic Discovery and Configuration With OpenTelemetry. Today, you have become familiar with how easy it is to add tracing, Code Profiling and Database Query Performance to your existing Java application in Kubernetes to immediately improve the observability of your applications and infrastructure.
+description: Congratulations, you have completed the Spring PetClinic Spring Boot Based Microservices On Kubernetes workshop. Today, you have become familiar with how easy it is to add tracing, Code Profiling and Database Query Performance to your existing Java applications in Kubernetes to immediately improve the observability of your applications and infrastructure.
 ---
 
-Congratulations, you have completed the **Get the Most Out of Your Existing Kubernetes Java Applications Using Automatic Discovery and Configuration With OpenTelemetry** workshop.
+Congratulations, you have completed the **Spring PetClinic Spring Boot Based Microservices On Kubernetes** workshop.
 
-Today, you have learned how easy it is to add Tracing, Code Profiling and Database Query Performance to your existing Java application in Kubernetes.
+Today, you have learned how easy it is to add Tracing, Code Profiling and Database Query Performance to your existing Java applications in Kubernetes.
 
 You immediately improved the observability of the application and infrastructure without touching a line of code or configuration using **Automatic Discovery and Configuration**.
 


### PR DESCRIPTION
## Summary

Updated reference to old workshop name


## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:**  `ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/9-wrap-up/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
