### PR TITLE
Theme update markdown fixes

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.11.2/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.11.7/assets/*"
    ]
   }
  }

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-1-request-lifecycle.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-1-request-lifecycle.md
@@ -52,13 +52,10 @@ A helpful way to explain this is:
 
 Where does the LangGraph workflow actually start executing in this API flow?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 It starts inside `plan_travel_internal()`. The Flask route only receives
 the request and extracts parameters. `plan_travel_internal()` initializes
 the workflow state and invokes the LangGraph graph, which then runs the nodes
 (coordinator, specialists, synthesizer) that update the state until
 the final itinerary is produced.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-2-shared-state.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-2-shared-state.md
@@ -44,9 +44,7 @@ How would you explain the syntax used for the `messages` field?
 messages: Annotated[List[AnyMessage], add_messages]
 ```
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 `messages: Annotated[List[AnyMessage], add_messages]` does two things.
 
 * `List[AnyMessage]` defines the **type** of the field: it’s a list of LangChain message objects (system, human, or AI messages).
@@ -54,5 +52,4 @@ messages: Annotated[List[AnyMessage], add_messages]
 
 Specifically, `add_messages` means that when a node writes new messages, LangGraph will **append them to the existing list instead of overwriting it**.
 So the conversation history grows as each node adds messages.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-3-orchestration.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-3-orchestration.md
@@ -55,24 +55,18 @@ This function implements the following application lifecycle:
 Why does the code use `compiled_app.stream(initial_state, config)` instead of
 simply calling the graph once and getting the final result?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Because streaming executes the workflow **step by step as each node runs**. This lets
 the application observe intermediate states, track which node is executing,
 and monitor the workflow in real time instead of waiting only for the final output.
-
-</details>
+{{< /details >}}
 
 #### Question 2
 
 Why do we create an `initial_state` before running the graph?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Because LangGraph workflows operate on a shared state object. The `initial_state`
 provides the starting data that nodes will read from, update, and pass along as
 the workflow progresses.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-4-graph-definition.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-4-graph-definition.md
@@ -54,12 +54,9 @@ Even though this uses conditional edges, the workflow is effectively linear:
 If the workflow is effectively linear, why does the graph still use
 `add_conditional_edges` and the `should_continue()` router?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Because it makes the workflow **flexible and extensible**. Even though the current flow
 is linear, the routing function allows the graph to dynamically decide the next node
 based on the state. This makes it easy to add branching, retries, or different
 execution paths later without redesigning the graph.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-5-node-definition.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-5-node-definition.md
@@ -48,9 +48,7 @@ The hotel and activity nodes follow the same structure, which makes the workflow
 When creating the LLM for the `flight_specialist` node, we specified
 a temperature of `0.4`. What does this mean?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Temperature controls how random or creative the model’s responses are.
 
 * **Lower temperature (e.g., 0.0–0.3)**: more deterministic and consistent responses
@@ -60,5 +58,4 @@ Temperature controls how random or creative the model’s responses are.
 So setting **temperature=0.4** means the `flight_specialist` agent will produce
 responses that are **mostly consistent and reliable, with a small amount of
 variation**, which useful for tasks that need correctness but not completely rigid answers.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-6-message-abstractions.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-6-message-abstractions.md
@@ -37,13 +37,10 @@ result = llm.invoke(messages)
 
 How would you define system, human, and AI messages?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 In LangChain and LangGraph, messages are typically categorized by who is speaking and what role they play in guiding the conversation:
 
 * **System message**: Sets the rules and context for the AI’s behavior. It defines instructions, constraints, tone, and goals that guide how the model should respond throughout the interaction.
 * **Human message**: Input from the user. It contains questions, requests, or information that the AI should respond to.
 * **AI message**: The model’s response. It represents the assistant’s generated output based on the system instructions and human input.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-7-llm-creation.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-7-llm-creation.md
@@ -29,9 +29,7 @@ creative they should be.
 
 How would you create an LLM for Azure OpenAI (rather than OpenAI?)
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Creating an LLM for Azure OpenAI has a few differences. The function would return a `AzureChatOpenAI`
 object instead of `ChatOpenAI`.
 
@@ -51,5 +49,4 @@ def _create_llm(agent_name: str, *, temperature: float, session_id: str) -> Azur
         # AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment variables will be used to connect to the LLM
     )
 ```
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-8-decomposition-pattern.md
+++ b/content/en/ninja-workshops/ai/18-agentic-ai/4-review-agentic-ai-app/4-8-decomposition-pattern.md
@@ -57,14 +57,11 @@ That is one of the main architectural ideas you should take away from this overv
 Why does the app use a separate `plan_synthesizer` node instead of letting
 one agent generate the entire travel plan?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 Because the system breaks the problem into **specialized tasks** first (flights, hotels, activities).
 Each specialist produces a focused summary, and the `plan_synthesizer` node then **combines those
 outputs into one coherent itinerary**.
 
 This pattern improves **modularity, reliability, and observability**, since each agent
 handles a smaller problem and the final node integrates the results.
-
-</details>
+{{< /details >}}

--- a/content/en/ninja-workshops/instrumentation/4-synthetics-scripting/_index.md
+++ b/content/en/ninja-workshops/instrumentation/4-synthetics-scripting/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Splunk Synthetic Scripting
+title: Synthetic Scripting
 description: Proactively find and fix performance issues across user flows, business transactions and APIs to deliver better digital experiences.
 weight: 4
 authors: ["Robert Castley"]

--- a/content/en/ninja-workshops/instrumentation/8-docker-k8s-otel/4-instrument-app-with-otel.md
+++ b/content/en/ninja-workshops/instrumentation/8-docker-k8s-otel/4-instrument-app-with-otel.md
@@ -79,9 +79,7 @@ dotnet run
 
 How can we see what traces are being exported by the .NET application from our Linux instance?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 There are two ways we can do this:
 
 1. We could add `OTEL_TRACES_EXPORTER=otlp,console` at the start of the `dotnet run` command, which ensures that traces are both written to collector via OTLP as well as the console.
@@ -104,7 +102,7 @@ service:
       - resourcedetection
       exporters: [otlphttp, signalfx, debug]
 ```
-</details>
+{{< /details >}}
 
 ## Access the Application
 

--- a/content/en/ninja-workshops/instrumentation/8-docker-k8s-otel/8-deploy-app-k8s.md
+++ b/content/en/ninja-workshops/instrumentation/8-docker-k8s-otel/8-deploy-app-k8s.md
@@ -294,9 +294,7 @@ After a minute or so, you should see traces flowing in the o11y cloud. But, if y
 
 If you are a developer and just want to quickly grab the trace id or see console feedback, what environment variable could you add to the deployment.yaml file?
 
-<details>
-  <summary><b>Click here to see the answer</b></summary>
-
+{{< details summary="Click here to see the answer" >}}
 If you recall in our challenge from Section 4, *Instrument a .NET Application with OpenTelemetry*, we showed you a trick to write traces to the console using the `OTEL_TRACES_EXPORTER` environment variable. We can add this variable to our deployment.yaml, redeploy our application, and tail the logs from our helloworld app so that we can grab the trace id to then find the trace in Splunk Observability Cloud. (In the next section of our workshop, we will also walk through using the debug exporter, which is how you would typically debug your application in a K8s environment.)
 
 First, open the deployment.yaml file in vi:
@@ -398,5 +396,4 @@ Resource associated with Activity:
 {{< /tabs >}}
 
 Then, in your other terminal window, generate a trace with your curl command. You will see the trace id in the console in which you are tailing the logs. Copy the `Activity.TraceId:` value and paste it into the Trace search field in APM.
-
-</details>
+{{< /details >}}

--- a/content/en/workshop-setup/1-swipe.md
+++ b/content/en/workshop-setup/1-swipe.md
@@ -1,13 +1,13 @@
 ---
-title: 1. Using SWiPE
+title: Using SWiPE
 weight: 1
+time: false
 ---
 
-##### **Configure your Org using SWiPE**
+## **Configure your Org using SWiPE**
 
-{{% notice style="info" title="Important Information" %}}
-**SWiPE** does **not** provision EC2 instances. These instances are provisioned separately using **Splunk Show**.
-{{% /notice %}}
+> [!IMPORTANT] Important
+> **SWiPE** does **not** provision EC2 instances. These instances are provisioned separately using **Splunk Show**.
 
 **SWiPE** is an online tool designed to help you configure a workshop environment in Splunk Observability Cloud. You can access **SWiPE** [**here**](https://swipe.splunk.show).
 
@@ -15,22 +15,36 @@ weight: 1
 
 **SWiPE** will perform the following tasks your workshop environment:
 
-1. **Create and Invite Users to the Organization**
-    - Upload a `.csv` file containing the email addresses (one per line), **or** copy and paste the email addresses directly (one per line).
-    - **NOTE:** Users will immediately be sent an email invitation to join the organization.
+{{< step "**Create and Invite Users to the Organization**" "1" >}}
 
-2. **Configure Admin Access for Ninja Workshops**
-   - If the **Ninja Workshop** option is enabled, all users will be provisioned with **Admin** access control.
+- Upload a `.csv` file containing the email addresses (one per line), **or** copy and paste the email addresses directly (one per line).
+- **NOTE:** Users will immediately be sent an email invitation to join the organization.
 
-3. **Configure a Custom HEC URL and Token (Optional)**
-   - If **Override HEC URL and Token** is enabled, you can configure a custom HTTP Event Collector (HEC) URL and token. This overrides the default values used for sending logs to Splunk Cloud.
+{{< /step >}}
 
-4. **Create a Team and Add Users**
-   - **SWiPE** will create a team and automatically add all the users.
+{{< step "**Configure Admin Access for Ninja Workshops**" "2" >}}
 
-5. **Generate a SWiPE ID**
-   - **SWiPE** will create a unique **SWiPE ID** for your workshop. You will need to copy this ID and use it when provisioning workshop instances in [**Splunk Show**](https://show.splunk.com/home/).
+- If the **Ninja Workshop** option is enabled, all users will be provisioned with **Admin** access control.
 
-{{% notice style="warning" title="**Workshops with more than 40 users**" %}}
-If your workshop has more than **40 users**, we recommend informing the support team in advance. This ensures that the trial or workshop environment is properly scaled to handle the load.
-{{% /notice %}}
+{{< /step >}}
+
+{{< step "**Configure a Custom HEC URL and Token (Optional)**" "3" >}}
+
+- If **Override HEC URL and Token** is enabled, you can configure a custom HTTP Event Collector (HEC) URL and token. This overrides the default values used for sending logs to Splunk Cloud.
+
+{{< /step >}}
+
+{{< step "**Create a Team and Add Users**" "4" >}}
+
+- **SWiPE** will create a team and automatically add all the users.
+
+{{< /step >}}
+
+{{< step "**Generate a SWiPE ID**" "5" >}}
+
+- **SWiPE** will create a unique **SWiPE ID** for your workshop. You will need to copy this ID and use it when provisioning workshop instances in [**Splunk Show**](https://show.splunk.com/home/).
+
+{{< /step >}}
+
+> [!WARNING] Workshops with more than 40 users
+> If your workshop has more than **40 users**, we recommend informing the support team in advance. This ensures that the trial or workshop environment is properly scaled to handle the load.

--- a/content/en/workshop-setup/2-splunk-show.md
+++ b/content/en/workshop-setup/2-splunk-show.md
@@ -1,6 +1,7 @@
 ---
-title: 2. Using Splunk Show
+title: Using Splunk Show
 weight: 2
+time: false
 ---
 
 ## **Observability Workshop Templates**

--- a/content/en/workshop-setup/3-clean-up.md
+++ b/content/en/workshop-setup/3-clean-up.md
@@ -1,15 +1,16 @@
 ---
-title: 3. Workshop Clean-up
+title: Workshop Clean-up
 weight: 3
+time: false
 ---
 
-##### **Workshop Cleanup**
+## **Workshop Cleanup**
 
 After completing your workshop session, it’s important to clean up the environment to save costs and ensure resources are properly managed. Use **SWiPE** to handle the cleanup process efficiently.
 
 ---
 
-##### **What SWiPE Deletes**
+### **What SWiPE Deletes**
 
 SWiPE automates the following cleanup tasks:
 
@@ -22,13 +23,13 @@ SWiPE automates the following cleanup tasks:
 
 ---
 
-##### **Advanced Cleanup Features**
+### **Advanced Cleanup Features**
 
 SWiPE also offers advanced cleanup options, such as deleting tokens and detectors. Use these features **with caution**, as they permanently remove resources.
 
 ---
 
-##### **Don’t Forget to Delete Workshop Instances**
+### **Don’t Forget to Delete Workshop Instances**
 
 In addition to using SWiPE, ensure you **delete your workshop instances** in [**Splunk Show**](https://show.splunk.com) to avoid unnecessary costs.
 

--- a/content/en/workshop-setup/4-org-configuration.md
+++ b/content/en/workshop-setup/4-org-configuration.md
@@ -1,11 +1,12 @@
 ---
-title: 4. Trial Org Configuration
+title: Trial Org Configuration
 weight: 4
+time: false
 ---
 
 ## Log Observer Connect
 
-The workshops require a Log Observer Connect configuration to be setup. This is required to be able to send logs from the workshop instances to Splunk Cloud/Enterprise. **SWiPE** provides a simple form to configure this and is available [**here**](https://swipe.splunk.show/log_observer_connect).
+The workshops require a Log Observer Connect configuration to be setup. This is required to be able to send logs from the workshop instances to Splunk Cloud/Enterprise. **SWiPE** provides a simple form to configure this. You can find this form in the **Tools** section of SWiPE.
 
 ![Log Observer Connect](../images/log-observer-connect.png)
 

--- a/content/en/workshop-setup/5-presenter-mode.md
+++ b/content/en/workshop-setup/5-presenter-mode.md
@@ -1,15 +1,16 @@
 ---
-title: 5. Presenter Mode
+title: Presenter Mode
 weight: 5
+time: false
 ---
 
-##### **What is Presenter Mode?**
+## **What is Presenter Mode?**
 
 Presenter mode reveals delivery cues — timing hints, "kick this off in the background now" prompts, and other guidance for the person running the workshop — that are hidden from attendees by default. Notes are authored inline alongside the step they relate to, so you see them in context while presenting.
 
 ---
 
-##### **Turning Presenter Mode On**
+### **Turning Presenter Mode On**
 
 Append `?presenter=1` to **any** workshop URL and load the page once. For example:
 
@@ -23,15 +24,11 @@ After that, a magenta **Presenter on** pill appears in the bottom-right corner o
 Bookmark the workshop home page with `?presenter=1` already in the URL. Opening that bookmark on a fresh browser/device flips presenter mode on for you.
 {{% /notice %}}
 
----
-
-##### **Turning Presenter Mode Off**
+### **Turning Presenter Mode Off**
 
 Click the magenta **Presenter on** pill in the bottom-right corner. The pill disappears and the notes are hidden again.
 
----
-
-##### **Authoring Presenter Notes**
+### **Authoring Presenter Notes**
 
 Wrap any guidance in the `presenter` shortcode. The note can contain regular Markdown (lists, code, links, images):
 
@@ -53,9 +50,8 @@ Here's a live example — you'll only see it rendered if you're currently in pre
 This is what a presenter note looks like. If you can read this, presenter mode is on.
 {{< /presenter >}}
 
----
 
-##### **What Attendees See**
+### **What Attendees See**
 
 Nothing. The notes are not rendered, and the toggle pill is not displayed for them.
 

--- a/content/en/workshop-setup/_index.md
+++ b/content/en/workshop-setup/_index.md
@@ -5,30 +5,25 @@ linkTitle: Workshop Setup
 hidden: true
 ---
 
-##### **Welcome to the Observability Workshop Setup Guide**
+## **Welcome to the Observability Workshop Setup Guide**
 
 This guide will walk you through the steps required to set up your workshop environments in Splunk Observability Cloud. Whether you’re using a pre-configured organization or setting up a trial, this guide has you covered.
 
----
-
-##### **Splunk4Rookies - Observability Cloud Workshop Presentation**
+### **Splunk4Rookies - Observability Cloud Workshop Presentation**
 
 The official workshop presentation is available on the [**Cisco Sharepoint**](https://cisco.sharepoint.com/:p:/s/spk_splunkshowcontentrepo/EVOz38iE_mVU5ejCZMOkQE8BN9YSp5VvabMLhPTGUWddpg). Use this resource to guide your workshop participants through the material.
 
----
-
-##### **Provided Organizations (For Splunk Employees Only)**
+### **Provided Organizations (For Splunk Employees Only)**
 
 If you’re a Splunk employee, you can use the following pre-configured organizations to run Observability Workshops. These organizations have all the necessary features enabled to support any of the available workshops:
 
-##### **Available Workshop Organizations**
+- **Available Workshop Organizations**
+  - **[CoE Workshop EMEA (EU0)](https://app.eu0.signalfx.com/#/home/EsGF1sXAEAA)**
+  - **[Observability Workshop EMEA (EU0)](https://app.eu0.signalfx.com/#/home/EaJHc4vAEAA)**
+  - **[Observability Workshop AMER (US1)](https://app.us1.signalfx.com/#/home/EPNXccRAwAA)**
+  - **[APAC-O11y-Workshop (US1)](https://app.us1.signalfx.com/#/home/FA-6LDcA4AA)**
 
-- **[CoE Workshop EMEA (EU0)](https://app.eu0.signalfx.com/#/home/EsGF1sXAEAA)**
-- **[Observability Workshop EMEA (EU0)](https://app.eu0.signalfx.com/#/home/EaJHc4vAEAA)**
-- **[Observability Workshop AMER (US1)](https://app.us1.signalfx.com/#/home/EPNXccRAwAA)**
-- **[APAC-O11y-Workshop (US1)](https://app.us1.signalfx.com/#/home/FA-6LDcA4AA)**
-
-##### **Blocked Organizations**
+### **Blocked Organizations**
 
 The following organizations are **blocked** and cannot be used for running workshops:
 
@@ -36,9 +31,7 @@ The following organizations are **blocked** and cannot be used for running works
 - **US Splunk Show (US1)**
 - **Show Playground (US1)**
 
----
-
-##### **Trial Organizations**
+### **Trial Organizations**
 
 If you’re not using a pre-configured organization, you can create a workshop environment in any **trial organization**. A default trial provides the following resources per month:
 
@@ -46,19 +39,19 @@ If you’re not using a pre-configured organization, you can create a workshop e
 - 25 APM hosts
 - 25 x 10k RUM sessions
 
-##### **Limitations in Trial Orgs**
+### **Limitations in Trial Orgs**
 
 The following feature is **not available** in trial organizations by default and must be enabled:
 
 - **Synthetic Monitoring**
 
-##### **Splunk Cloud/Enterprise Requirements**
+### **Splunk Cloud/Enterprise Requirements**
 
 To send logs to Splunk Observability Cloud, you’ll need access to a **Splunk Cloud** or **Splunk Enterprise** environment. Ensure the following:
 
 - An index named **splunk4rookies-workshop** exists in your Splunk environment.  
 - Log Observer Connect is configured. If you’re using **Splunk Enterprise** or **Splunk Cloud Platform**, follow the [**Log Observer Connect setup instructions**](https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/introduction-to-splunk-log-observer-connect).
 
-##### **Trial Org Configuration**
+### **Trial Org Configuration**
 
 For new trial organizations, you’ll also need to complete the steps outlined in the [**Trial Org Configuration**](4-org-configuration) section.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.11.4 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.11.7 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.11.2 h1:6cWtrqiGKt4NDFlM+wIw0E6FcnCXWQ4PXNFCMlXwS/I=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.2/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.3 h1:ihFq/cGveronFdej0Utc1km55gIGkmjly0ZOGaaMMQI=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.3/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.4 h1:+S3tWlMZpdcicNb7+onT2J0udlfrKn+SBnRt1UmzPlg=
-github.com/splunk/hugo-theme-splunk-workshop v0.11.4/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.7 h1:a5ZIKzIFOaydftlxoxlh30qm8uKiIy8Kn4tfe3Q4gKE=
+github.com/splunk/hugo-theme-splunk-workshop v0.11.7/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
## Summary

Theme bump and markdown fixes

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [ ] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [X] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [X] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:
