### PR TITLE
Markdownlint pass on the 19-context-propagation workshop

### DIFF
--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/1-workshop-overview/_index.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/1-workshop-overview/_index.md
@@ -2,7 +2,6 @@
 title: Workshop Overview
 linkTitle: 1. Workshop Overview
 weight: 1
-archetype: chapter
 time: 5 minutes
 description: Goals and architecture for the workshop.
 ---
@@ -16,7 +15,7 @@ In this Hands-on Workshop, we will instrument Python microservices with **Splunk
 ## Workshop Outline (~75 min)
 
 | # | Module | Time |
-|---|--------|------|
+| - | ------ | ---- |
 | 1 | [Prerequisites](docs/workshop/1-prerequisites.md) | 5 min |
 | 2 | [Deploy application services](docs/workshop/2-deploy-services.md) | 10 min |
 | 3 | [Deploy Splunk OTel Collector](docs/workshop/3-deploy-collector.md) | 10 min |
@@ -24,12 +23,11 @@ In this Hands-on Workshop, we will instrument Python microservices with **Splunk
 | 5 | [Tag Spotlight](docs/workshop/5-tag-spotlight.md) | 15 min |
 | 6 | [Summary](docs/workshop/6-summary.md) | 5 min |
 
-
 ## Application Architecture
 
 ### Request flow (application data)
 
-```
+```text
 Client / load-generator
     │
     ▼ HTTP

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/2-deploy-application/1-install-and-run.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/2-deploy-application/1-install-and-run.md
@@ -43,7 +43,9 @@ Kustomize Version: v5.8.1
 
 You're now ready to deploy application services on k3d
 
-## Set Up the Environment
+{{% exercise title="Install and Run" %}}
+
+### Set Up the Environment
 
 Navigate to the Phase 1 directory and create a virtual environment:
 
@@ -62,28 +64,26 @@ cd ~/workshop/context-propagation/scripts
 Creating k3d cluster 'trace-workshop'...
 INFO[0000] portmapping '8080:8080' targets the loadbalancer: defaulting to [servers:*:proxy agents:*:proxy] 
 INFO[0000] portmapping '13133:13133' targets the loadbalancer: defaulting to [servers:*:proxy agents:*:proxy] 
-INFO[0000] Prep: Network                                
-INFO[0000] Created network 'k3d-trace-workshop'         
+INFO[0000] Prep: Network
+INFO[0000] Created network 'k3d-trace-workshop'
 INFO[0000] Created image volume k3d-trace-workshop-images ...
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
-## Set Your Splunk Credentials
+### Set Your Splunk Credentials
 
 Export your credentials as environment variables. Replace each placeholder with your actual values:
 
-{{% notice title="Exercise" style="green" icon="running" %}}
 Your environment should have values for `ACCESS_TOKEN` and `REALM`when you type `env`
-
 
 ``` bash
 export CLUSTER_NAME=trace-workshop-"<YOUR_INITIALS>"
 export WORKSHOP_ENV="trace-propagation-<YOUR-INITIALS>"
 ```
 
-**If  some or all the values they do not exist export them as follows**
+If  some or all the values they do not exist export them as follows:
 
 ``` bash
 export ACCESS_TOKEN="<YOUR_TOKEN>"
@@ -92,11 +92,9 @@ export CLUSTER_NAME=trace-workshop-"<YOUR_INITIALS>"
 export WORKSHOP_ENV="trace-propagation-<YOUR-INITIALS>"
 ```
 
-{{% /notice %}}
+### Run the App
 
-## Run the App
-
-The app will automatically start in the background, run validation checks and send 2 (or ]up-to 15) requests. 
+The app will automatically start in the background, run validation checks and send 2 (or ]up-to 15) requests.
 
 Expected Outout
 
@@ -153,12 +151,13 @@ Health endpoints:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Check Splunk APM
+{{% /exercise %}}
+
+### Check Splunk APM
 
 1. Open [Splunk Observability Cloud UI](http://app.us1.signalfx.com) (url depends on your workshop location) and search for `trace-propagation-<your initials>` in APM -> Service Map
 2. This will return no results..
 
-
 {{% notice title="Note" style="info" %}}
-At this point you have a running app and proof that there is no data in Splunk. The app has no instrumentation code whatsoever.. 
+At this point you have a running app and proof that there is no data in Splunk. The app has no instrumentation code whatsoever.
 {{% /notice %}}

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/2-deploy-application/_index.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/2-deploy-application/_index.md
@@ -2,7 +2,6 @@
 title: "Phase 1: Deploy Python Microservices"
 linkTitle: 2. Deploy Python Microservices
 weight: 2
-archetype: chapter
 time: 15 minutes
 description: Deploy and run Python microservices on a k3d host, verify that the application is running correctly. 
 ---

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/1-configure-and-start.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/1-configure-and-start.md
@@ -5,7 +5,7 @@ weight: 1
 
 ## Verify or Add Your Splunk Credentials
 
-{{% notice title="Exercise" style="green" icon="running" %}}
+{{% exercise title="Configure and Start" %}}
 
 ``` bash
 echo $ACCESS_TOKEN; echo $REALM; echo $INSTANCE
@@ -25,7 +25,7 @@ SPLUNK_REALM=<YOUR-REALM>
 WORKSHOP_ENV=trace-propagation-<YOUR-INITIALS>
 ```
 
-## Deploy the collector
+### Deploy the collector
 
 This script:
 
@@ -67,7 +67,7 @@ Validating collector health...
 The workshop deploys two collector workloads:
 
 | Workload | Role |
-|----------|------|
+| -------- | ---- |
 | `deployment/splunk-otel-collector` | OTLP gateway + **k8s_cluster** receiver (cluster infrastructure metrics) |
 | `daemonset/splunk-otel-collector-agent` | **hostmetrics** + **kubeletstats** (node, pod, container metrics) |
 
@@ -75,16 +75,19 @@ The workshop deploys two collector workloads:
 - **Gateway config:** `k8s/splunk-otel-collector/workshop-config.yaml`
 - **Agent config:** `k8s/splunk-otel-collector/agent-config.yaml`
 
-## Confirm collector health
+### Confirm collector health
 
 ```bash
 curl -s http://localhost:13133/
 ```
 
-## Check collector logs:
+### Check collector logs
+
 Confirm the collector starts without pipeline errors (no repeated `401`, `403`, or export failures).
 
 ```bash
 kubectl logs deployment/splunk-otel-collector -n trace-workshop --tail 20
 kubectl logs daemonset/splunk-otel-collector-agent -n trace-workshop --tail 20
 ```
+
+{{%/ exercise %}}

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/2-generate-traffic.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/2-generate-traffic.md
@@ -3,19 +3,19 @@ title: 2. (Optional) Generate Traffic
 weight: 2
 ---
 
-## Confirm Collector Health
+{{% exercise title="Generate Traffic" %}}
+
+### Confirm Collector Health
 
 ```bash
 curl -s http://localhost:13133/
 ```
 
-## Generate Traffic
+---
 
-{{% notice title="Exercise" style="green" icon="running" %}}
+### Generate Traffic
 
 Allow **2–5 minutes** after the first request for services to appear.
-
-{{% /notice %}}
 
 ```bash
 curl -s http://localhost:8080/api/order | jq '{order_id, product, tier, amount, inventory: .inventory.reserved, payment: .payment.approved, fulfilment: .fulfilment.carrier}'
@@ -43,4 +43,4 @@ You should see a JSON response like:
 
 The request flows through all services. But right now, the data is fragmented in Splunk.
 
-
+{{% /exercise %}}

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/3-check-splunk.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/3-check-splunk.md
@@ -22,13 +22,12 @@ All infrastructure metrics are tagged with `k8s.cluster.name=trace-workshop-<you
 If infrastructure metrics are missing:
 
 | Check | Action |
-|-------|--------|
+| ----- | ------ |
 | Agent DaemonSet | `kubectl get pods -n trace-workshop -l app=splunk-otel-collector-agent` — all Ready |
 | Agent logs | `kubectl logs daemonset/splunk-otel-collector-agent -n trace-workshop` — no kubelet TLS errors |
 | RBAC | ServiceAccount `splunk-otel-collector` has ClusterRole `splunk-otel-collector-workshop` |
 | Token | Ingest token must include **Infrastructure Monitoring** permissions |
 | Cluster filter | Set **k8s.cluster.name** = `trace-workshop` in Splunk IMM |
-
 
 ## Confirm APM Data in Splunk
 
@@ -39,7 +38,7 @@ If infrastructure metrics are missing:
 If services do not appear:
 
 | Check | Action |
-|-------|--------|
+| ----- | ------ |
 | Token | Use an **ingest** access token with APM permissions (not a RUM-only token) |
 | Realm | Match `SPLUNK_REALM` to your org (US0 → `us0`, EU0 → `eu0`) |
 | Environment filter | In APM, set **Environment** = your `WORKSHOP_ENV` |
@@ -56,13 +55,12 @@ If services do not appear:
 ### What you should see after the collector is live
 
 | Hop | Splunk trace behavior |
-|-----|----------------------|
+| --- | --------------------- |
 | **storefront → inventory-service** | **Correlated** — spans for both services appear in the **same trace** |
 | **storefront → payment-service** | **Not correlated** — `payment-service` appears as a **separate root trace** |
 | **payment-proxy** | Usually in the **same trace as storefront** (inbound from storefront); the break is on the **outbound** hop to payment |
 | **payment-service → order-service** | **Correlated** — HTTP from payment to order links in **one trace** (payment’s root trace) |
 | **order-service → RabbitMQ → fulfilment-service** | **RabbitMQ shows as an inferred service** on the order trace (publish/receive spans with `messaging.system=rabbitmq`, `server.address=rabbitmq`). **order and fulfilment traces stay disconnected** — no trace context on AMQP messages in Phase 1 |
-
 
 {{% notice title="Exercise" style="green" icon="running" %}}
 
@@ -77,7 +75,7 @@ In **APM → Service map**, dependencies appear even when Trace Analyzer waterfa
 {{% /notice %}}
 
 | Hop | What happens |
-|-----|----------------|
+| --- | ------------ |
 | Client → edge proxy | `traceparent` removed before storefront |
 | Storefront → **inventory** (direct HTTP) | `filter_headers_for_mode()` removes headers from `inject_outbound_headers()`, but the Splunk OTel **`requests` auto-instrumentation** still injects W3C `traceparent`. **inventory-service** (`auto` mode) extracts W3C — traces link. |
 | Storefront → **payment-proxy** | Same `requests` instrumentation may link storefront and payment-proxy on the inbound hop |

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/_index.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/3-deploy-splunk-otel-collector/_index.md
@@ -2,7 +2,6 @@
 title: "Phase 2: Install Splunk Otel Collector"
 linkTitle: 3. Install Splunk Otel Collector
 weight: 3
-archetype: chapter
 time: 30 minutes
 description: Deploy Splunk Otel Collector to collect Host Metrics and Instrument the App.
 ---

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/5-wrap-up/_index.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/5-wrap-up/_index.md
@@ -2,12 +2,11 @@
 title: Wrap-Up
 linkTitle: 6. Wrap-Up
 weight: 6
-archetype: chapter
 time: 5 minutes
 description: Key takeaways & cleanup instructions.
 ---
 
-# Summary
+## Summary
 
 This workshop provided hands-on experience with:
 
@@ -20,13 +19,12 @@ This workshop provided hands-on experience with:
 ## Reference Segments Commands
 
 | Action | Command |
-|--------|---------|
+| ------ | ------- |
 | Step 1 — Deploy Services | `start-lab.sh` |
 | Step 2 — Deploy Collector | `deploy-collector.sh` |
 | Step 3 - Continuous Load | `start-load.sh` |
 | Step 4 - Manual Propagation (code guides) | manual-propagation.md |
 | Step 5 - Stop & clean-Up Stack | `teardown.sh` |
-
 
 ## Clean Up
 

--- a/content/en/ninja-workshops/instrumentation/19-context-propagation/_index.md
+++ b/content/en/ninja-workshops/instrumentation/19-context-propagation/_index.md
@@ -1,10 +1,9 @@
 ---
 draft: true
-hidden: true
 title: Manual Trace Propagation
 linkTitle: Manual Trace Propagation
 weight: 19
-archetype: chapter
+layout: chapter
 time: 90 minutes
 authors: ["Diana Omuoyo"]
 description: Instrument a containerized Python application with Splunk OpenTelemetry, observe fragmented traces when W3C headers are stripped, and fix issue with manual context propagation.


### PR DESCRIPTION
Mechanical lint fixes across the 9 markdown files in the workshop — fence spacing, list spacing, blank lines around headings, trailing whitespace, list-style consistency, and final-newline normalisation. No content rewrites.

