### PR TITLE
Fix markdown syntax issue

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/3-verify-setup/_index.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/3-verify-setup/_index.md
@@ -7,7 +7,7 @@ time: 10 minutes
 
 Once the installation has completed, you can log in to **Splunk Observability Cloud** and verify that the metrics are flowing in from your Kubernetes cluster.
 
-From the left-hand menu, click on **Infrastructure** and select **Kubernetes overview**. You will be prompted to apply at least one filter. Click inside the **k8s.cluster.name** field, then select the `<INSTANCE>-k3s-cluster` (where`<INSTANCE>` is replaced with the value you noted down earlier). Click **Apply Filters**.
+From the left-hand menu, click on **Infrastructure** and select **Kubernetes overview**. You will be prompted to apply at least one filter. Click inside the **k8s.cluster.name** field, then select `<INSTANCE>-k3s-cluster` (where`<INSTANCE>` is replaced with the value you noted down earlier). Click **Apply Filters**.
 
 ![K8s Filter Dialog](../images/k8s-filter-dialog.png)
 
@@ -15,7 +15,7 @@ Once you are in the **Kubernetes overview**, select the **Nodes (3)** card title
 
 ![K8s Overview](../images/k8s-overview.png)
 
-Next, in the **Kubernetes entities** panel, select the node that hosts the largest number of pods. It will be named 'k3d-<INSTANCE>-cluster-server-0' or similar.
+Next, in the **Kubernetes entities** panel, select the node that hosts the largest number of pods. It will be named `k3d-<INSTANCE>-cluster-server-0` or similar.
 
 ![K8s Node List](../images/k8s-node-list.png)
 


### PR DESCRIPTION
## Summary

Fixed issue where a use of `<INSTANCE>` wasn't rendering in output correctly due to use of single-quote instead of backtick in markdown syntax. Minor additional edits for readability.

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** `ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/3-verify-setup/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
