### PR TITLE
Update 2-trace.md to add note to open trace 

### DIFF
--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/2-trace.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/2-trace.md
@@ -6,9 +6,12 @@ weight: 2
 
 To pick a trace, select a line in the `Service Requests & Errors` chart **(1)**. A selection of related traces will appear.
 
-Once you have the list of related traces, click on the blue **(2)** Trace ID Link, making sure the trace you select has the same three services mentioned in the Services Column.
+Once you have the list of related traces, right-click on the blue **(2)** Trace ID Link and open the trace in a new browser tab, making sure the trace you select has the same three services mentioned in the Services Column.
 
 ![workflow-trace-pick](../../images/selecting-a-trace.png)
+
+> [!NOTE]
+> _Be sure to open the trace in a new browser tab, as we will refer back to the same trace in later sections. Opening the trace in a new tab will save time and streamline navigation later._
 
 This brings us to the selected Trace in the Waterfall view:
 


### PR DESCRIPTION
## Summary

Added note to open trace in a new browser tab to make it easier to revisit the same trace later, in section 6.


## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** `ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/5-traces/2-trace/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
