### PR TITLE
Remove redundant `---` horizontal rules from OTel Collector workshop

### DIFF
--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/1-installation/1-confirmation.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/1-installation/1-confirmation.md
@@ -203,8 +203,6 @@ Which leave you with the following directory structure:
 
 {{% /expand %}}
 
----
-
 ## Default configuration
 
 OpenTelemetry is configured through YAML files. These files have default configurations that we can modify to meet our needs. Let's look at the default configuration that is supplied:

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/2-extensions/3-zpages.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/2-extensions/3-zpages.md
@@ -266,13 +266,9 @@ There is a potential that this could impact data throughput performance due to d
 
 {{% /expand %}}
 
----
-
 ## Configuration Check-in
 
 Now that we've covered extensions, let's check our configuration changes.
-
----
 
 {{% expand title="{{% badge icon=check color=green title=**Check-in** %}}Review your configuration{{% /badge %}}" %}}
 {{< tabs >}}
@@ -355,8 +351,6 @@ service:
 {{% /tab %}}
 {{< /tabs >}}
 {{% /expand %}}
-
----
 
 Now that we have reviewed extensions, let's dive into the data pipeline portion of the workshop. A pipeline defines a path the data follows in the Collector starting from reception, moving to  further processing or modification, and finally exiting the Collector via exporters.
 

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/3-receivers/3-other-receivers.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/3-receivers/3-other-receivers.md
@@ -50,13 +50,9 @@ For more examples, refer to these [receiver creator's examples](https://github.c
 
 {{% /expand %}}
 
----
-
 ## Configuration Check-in
 
 We've now covered receivers, so let's now check our configuration changes.
-
----
 
 {{% expand title="{{% badge icon=check color=green title=**Check-in** %}}Review your configuration{{% /badge %}}" %}}
 {{< tabs >}}
@@ -161,8 +157,6 @@ service:
 {{% /tab %}}
 {{< /tabs >}}
 {{% /expand %}}
-
----
 
 Now that we have reviewed how data gets into the OpenTelemetry Collector through receivers, let's now take a look at how the Collector processes the received data.
 

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/4-processors/3-attributes.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/4-processors/3-attributes.md
@@ -75,13 +75,9 @@ A connector only accepts data exported from one pipeline and receiver by another
 
 {{% /expand %}}
 
----
-
 ## Configuration Check-in
 
 That's processors covered, let's check our configuration changes.
-
----
 
 {{% expand title="{{% badge icon=check color=green title=**Check-in** %}}Review your configuration{{% /badge %}}" %}}
 {{< tabs >}}
@@ -197,5 +193,3 @@ service:
 {{% /tab %}}
 {{< /tabs >}}
 {{% /expand %}}
-
----

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/5-exporters/1-otlphttp.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/5-exporters/1-otlphttp.md
@@ -71,8 +71,6 @@ exporters:
 
 Now that we've covered exporters, let's check our configuration changes:
 
----
-
 {{% expand title="{{% badge icon=check color=green title=**Check-in** %}}Review your configuration{{% /badge %}}" %}}
 {{< tabs >}}
 {{% tab title="config.yaml" %}}
@@ -191,8 +189,6 @@ service:
 {{% /tab %}}
 {{< /tabs >}}
 {{% /expand %}}
-
----
 
 Of course, you can easily configure the `metrics_endpoint` to point to any other solution that supports the **OTLP** protocol.
 

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/6-service/5-otlphttp.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/6-service/5-otlphttp.md
@@ -93,11 +93,7 @@ service:
 
 {{% /expand %}}
 
----
-
 ## Final configuration
-
----
 
 {{% expand title="Review your final configuration" %}}
 
@@ -220,12 +216,10 @@ service:
 
 {{% /expand %}}
 
----
-
 {{% notice style="tip" %}}
 It is recommended that you validate your configuration file before restarting the collector. You can do this by pasting the contents of your `config.yaml` file into **[otelbin.io](https://www.otelbin.io/)**.
 
-{{% expand title="{{% badge color=green title=**Screenshot** %}}OTelBin{{% /badge %}}" %}}
+{{% expand title="**Screenshot**: OTelBin" %}}
 ![otelbin-validator](../../images/otelbin.png)
 {{% /expand %}}
 

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/8-develop/3-component.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/8-develop/3-component.md
@@ -46,7 +46,7 @@ keep to the principles that founded OpenTelemetry to begin with; A vendor agnost
 To help revisit the details, please read through [**Exporter Overview**](../5-exporters).
 
 {{% /tab %}}
-{{% tab title="{{% badge style=primary icon=star %}}**Ninja:** Connectors{{% /badge %}}"  %}}
+{{% tab title="Connectors" %}}
 
 This is a component type that was missed in the workshop since it is a relatively new addition to the collector, but the best way to think about a connector is that it is like a processor that allows it to be used across different telemetry types and pipelines. Meaning that a connector can accept data as logs, and output metrics, or accept metrics from one pipeline and provide metrics on the data it has observed.
 

--- a/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/_index.md
+++ b/content/en/ninja-workshops/foundations/3-opentelemetry-collector-workshops/1-opentelemetry-collector/_index.md
@@ -19,13 +19,9 @@ Throughout the workshop there will be expandable {{% badge style=primary icon=st
 
 Please note that the content in these sections may go out of date due to the frequent development being made to the OpenTelemetry project. Links will be provided in the event details are out of sync, please let us know if you spot something that needs updating.
 
----
-
 {{% expand title="{{% badge style=primary icon=star %}}**Ninja:** Test Me!{{% /badge %}}" %}}
 **By completing this workshop you will officially be an OpenTelemetry Collector Ninja!**
 {{% /expand %}}
-
----
 
 ## Target Audience
 

--- a/content/ja/other/opentelemetry-collector/1-installation/1-confirmation.md
+++ b/content/ja/other/opentelemetry-collector/1-installation/1-confirmation.md
@@ -44,7 +44,6 @@ May 16 08:23:39 ip-10-0-9-125 otelcol-contrib[1415]:         {"kind": "exporter"
 {{% /tab %}}
 {{< /tabs >}}
 
-
 {{% notice title="Tips: status表示を中止するには" style="info" %}}
 `systemctl status` コマンドの表示を中止するときは `q` キーを押してください。
 {{% /notice %}}
@@ -110,7 +109,7 @@ sudo systemctl restart otelcol-contrib
 - ocbのインストール
   - ocbバイナリーを [project releases](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/cmd%2Fbuilder%2Fv0.80.0)
     からダウンロードして、次のコマンドを実行します:
-    
+
     ```bash
     mv ocb_0.80.0_darwin_arm64 /usr/bin/ocb
     chmod 755 /usr/bin/ocb
@@ -154,7 +153,6 @@ sudo systemctl restart otelcol-contrib
 ## Ninja ゾーン
 
 必要なツールをすべてインストールしたら、以下のディレクトリ構造に従い、 `otelcol-builder.yaml` という新しいファイルを作成します:
-
 
 ``` bash
 .

--- a/content/ja/other/opentelemetry-collector/2-extensions/3-zpages.md
+++ b/content/ja/other/opentelemetry-collector/2-extensions/3-zpages.md
@@ -42,7 +42,7 @@ Example URL: [http://localhost:55679/debug/extensionz](http://localhost:55679/de
 
 {{% expand title="{{% badge style=primary icon=star %}}**Ninja:** storageエクステンションでデータの耐久性を向上させる{{% /badge %}}" %}}
 
-これをこなうには、ディストリビューションに `file_storage` エクステンションモジュールがインストールされていることを確認する必要があります。確認するには、`otelcol-contrib components` コマンドを実行します: 
+これをこなうには、ディストリビューションに `file_storage` エクステンションモジュールがインストールされていることを確認する必要があります。確認するには、`otelcol-contrib components` コマンドを実行します:
 
 {{< tabs >}}
 {{% tab title="Command" %}}

--- a/content/ja/other/opentelemetry-collector/8-develop/1-project-setup.md
+++ b/content/ja/other/opentelemetry-collector/8-develop/1-project-setup.md
@@ -25,7 +25,7 @@ weight: 9
 
 {{% expand title="{{% badge icon=check color=green title=**Check-in** %}}go.modをレビューする{{% /badge %}}" %}}
 
-`` text
+``` text
 module splunk.conf/workshop/example/jenkinscireceiver
 
 go 1.20


### PR DESCRIPTION
Drop the `---` separators that sat between {{% /expand %}} blocks and the following `##` heading on 11 pages of the Foundations OpenTelemetry Collector workshop (en + ja/other). The heading already provides visual separation and the theme renders these rules as full-width lines that read as section breaks where none is intended.

Same pattern applied to the unsupported APM Online Boutique page split and the `_index.md` page where stray rules followed expand blocks.
