### PR TITLE
Bump theme to v0.13.7

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.4/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.7/assets/*"
    ]
   }
  }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.6 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.7 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.13.6 h1:4ppy4AxGUw+jTacWCsa+8+U1Sp26RT0HWfJEo+S8c90=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.6/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.7 h1:GYhnkasTQ8HFbvcJCsSLf11RnXHby6ZxHieiVFL1m+A=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.7/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
Pulls in the nested-tabs fix — `{{% tabs %}}` blocks rendered inside `{{% exercise %}}` (and any other percent shortcode that re-renders its `.Inner` through `RenderString`) no longer collide with earlier top-level tabs blocks in `.Page.Store`. Each tabs instance is keyed on `.Position` instead of `.Ordinal` so the buckets stay distinct.

* go.mod / go.sum: v0.13.6 -> v0.13.7
* assets/jsconfig.json: IntelliSense path catches up to v0.13.7
