### PR TITLE
Fixed spelling error

### DIFF
--- a/content/en/scenarios/network-event-intelligence/1-getting-started/_index.md
+++ b/content/en/scenarios/network-event-intelligence/1-getting-started/_index.md
@@ -11,7 +11,7 @@ authors: ["Chris Putnam", "Sam Scudere-Weiss", "Tim Hard"]
 
 Prior to this workshop you should have been provided details for accessing your workshop instance. This workshop utilizes a preconfigured environment which includes Splunk Enterprise and IT Service Intelligence. A link to the instance and the credentials are available in the Splunk Show instance details.
 
-All of the data required for completing this workshop is available in the `netops` index. This index includes data from  **Catalyst Center**, **Merkai**, and alerts from **Solarwinds**.
+All of the data required for completing this workshop is available in the `netops` index. This index includes data from  **Catalyst Center**, **Meraki**, and alerts from **Solarwinds**.
 
 An automated break scenario runs on a 30 minute cycle. The Catalyst Center sites will be healthy for 15 minutes, followed by 15 minutes of degraded performance. While the environment is unhealthy, Issues and Alerts are generated from **Catalyst Center** and **Solarwinds**.
 


### PR DESCRIPTION
## Summary

Fixed spelling error in the Network Event Intelligence intro 

Fixes # (optional — link an issue / ticket)

N/A

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [x] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** e.g. `content/en/scenarios/network-event-intelligence/1-getting-started/_index.md`

## Reviewer focus

Verify `Meraki` is spelled correctly in the introduction

## Screenshots / preview

N/A

## Verification

- [x] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
