### PR TITLE
Add ninja workshop 19: Galileo instrumentation for LangChain apps

### DIFF
--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/1-introduction.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/1-introduction.md
@@ -5,7 +5,7 @@ weight: 1
 time: 5 minutes
 ---
 
-In workshop 18 you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
+In [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
 (coordinator, flight specialist, hotel specialist, activity specialist, and synthesizer) calls an LLM
 through **LangChain**'s `ChatOpenAI`.
 
@@ -14,11 +14,11 @@ it. Rather than re-instrumenting from scratch, you'll attach a single Galileo ca
 workflow so every agent's LLM call is captured. This lets you compare and validate AI trace visibility
 across tools using a workload you already understand.
 
-{{% notice title="Prerequisites" style="orange" icon="info-circle" %}}
+{{% prerequisites title="Prerequisites" %}}
 
 * The workshop 18 travel planner app (`~/workshop/agentic-ai/base-app`), or your own copy of it.
 * A Galileo account and API key.
 * An OpenAI API key (the same `OPENAI_API_KEY` the app already uses).
 * Python 3.10+ environment with package install access.
 
-{{% /notice %}}
+{{% /prerequisites %}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/1-introduction.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/1-introduction.md
@@ -1,0 +1,24 @@
+---
+title: Introduction
+linkTitle: 1. Introduction
+weight: 1
+time: 5 minutes
+---
+
+In workshop 18 you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
+(coordinator, flight specialist, hotel specialist, activity specialist, and synthesizer) calls an LLM
+through **LangChain**'s `ChatOpenAI`.
+
+In this follow-on workshop, you will take that same application and add **Galileo instrumentation** to
+it. Rather than re-instrumenting from scratch, you'll attach a single Galileo callback to the LangGraph
+workflow so every agent's LLM call is captured. This lets you compare and validate AI trace visibility
+across tools using a workload you already understand.
+
+{{% notice title="Prerequisites" style="orange" icon="info-circle" %}}
+
+* The workshop 18 travel planner app (`~/workshop/agentic-ai/base-app`), or your own copy of it.
+* A Galileo account and API key.
+* An OpenAI API key (the same `OPENAI_API_KEY` the app already uses).
+* Python 3.10+ environment with package install access.
+
+{{% /notice %}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/2-quickstart-setup.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/2-quickstart-setup.md
@@ -7,15 +7,22 @@ time: 5 minutes
 
 Start by adding the Galileo SDK to the travel planner's environment and initializing Galileo tracing.
 
-1. Navigate to the app directory and activate the virtual environment you created in workshop 18
-   (or create a fresh one):
+{{< exercise title="Quickstart setup" >}}
+
+{{< step title="Activate Environment"  >}}
+
+Navigate to the app directory and activate the virtual environment you created in [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) (or create a fresh one):
 
 ```bash
 cd ~/workshop/agentic-ai/base-app
 source .venv/bin/activate
 ```
 
-2. Install the Galileo SDK alongside the app's existing dependencies:
+{{< /step >}}
+
+{{< step title="Install Galileo SDK"  >}}
+
+Install the Galileo SDK alongside the app's existing dependencies:
 
 ```bash
 pip install galileo python-dotenv
@@ -24,7 +31,11 @@ pip install galileo python-dotenv
 The app already installs `langchain`, `langchain-openai`, `langgraph`, and `flask` via its
 `requirements.txt`. Galileo's LangChain callback ships with the `galileo` package.
 
-3. Add your credentials to the app's `.env` file.
+{{< /step >}}
+
+{{< step title="Configure Galileo credentials"  >}}
+
+Add your credentials to the app's `.env` file.
 
 ```ini
 OPENAI_API_KEY="your-openai-api-key"
@@ -42,9 +53,10 @@ Uncommenting `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` keeps the workshop trace
 Leaving them commented is fine too — your traces will just land in the `default` project and
 `default` log stream.
 
-4. Initialize Galileo near the top of `main.py`, right after the existing imports and
-   `load_dotenv()` call. Passing the environment variables through means the project and log
-   stream come from your `.env` when set, and fall back to Galileo's `default`/`default` when not:
+{{< /step >}}
+
+{{< step title="Initialize Galileo in the app"  >}}
+Initialize Galileo near the top of `main.py`, right after the existing imports and `load_dotenv()` call. Passing the environment variables through means the project and log stream come from your `.env` when set, and fall back to Galileo's `default`/`default` when not:
 
 ```python
 import os
@@ -54,7 +66,11 @@ galileo_context.init(project=os.getenv("GALILEO_PROJECT"),
                      log_stream=os.getenv("GALILEO_LOG_STREAM"))
 ```
 
-### Knowledge Check
+{{< /step >}}
+
+{{< /exercise >}}
+
+{{< checkpoint title="Knowledge Check" >}}
 
 If you leave `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` commented out in your `.env`, where will
 your traces show up in Galileo?

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/2-quickstart-setup.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/2-quickstart-setup.md
@@ -1,0 +1,67 @@
+---
+title: Quickstart Setup
+linkTitle: 2. Quickstart Setup
+weight: 2
+time: 5 minutes
+---
+
+Start by adding the Galileo SDK to the travel planner's environment and initializing Galileo tracing.
+
+1. Navigate to the app directory and activate the virtual environment you created in workshop 18
+   (or create a fresh one):
+
+```bash
+cd ~/workshop/agentic-ai/base-app
+source .venv/bin/activate
+```
+
+2. Install the Galileo SDK alongside the app's existing dependencies:
+
+```bash
+pip install galileo python-dotenv
+```
+
+The app already installs `langchain`, `langchain-openai`, `langgraph`, and `flask` via its
+`requirements.txt`. Galileo's LangChain callback ships with the `galileo` package.
+
+3. Add your credentials to the app's `.env` file.
+
+```ini
+OPENAI_API_KEY="your-openai-api-key"
+OPENAI_BASE_URL="https://lite-llm-proxy.splunko11y.com/v1"
+GALILEO_API_KEY="your-galileo-api-key"
+GALILEO_CONSOLE_URL="https://console.multitenant.galileocloud.io"
+# Recommended: uncomment to group this workshop's traces under their own project
+# and log stream. If you leave these commented out, Galileo uses a project and log
+# stream both named "default".
+# GALILEO_PROJECT="Workshop19Galileo"
+# GALILEO_LOG_STREAM="TravelPlanner"
+```
+
+Uncommenting `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` keeps the workshop traces easy to find.
+Leaving them commented is fine too — your traces will just land in the `default` project and
+`default` log stream.
+
+4. Initialize Galileo near the top of `main.py`, right after the existing imports and
+   `load_dotenv()` call. Passing the environment variables through means the project and log
+   stream come from your `.env` when set, and fall back to Galileo's `default`/`default` when not:
+
+```python
+import os
+from galileo import galileo_context
+
+galileo_context.init(project=os.getenv("GALILEO_PROJECT"),
+                     log_stream=os.getenv("GALILEO_LOG_STREAM"))
+```
+
+### Knowledge Check
+
+If you leave `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` commented out in your `.env`, where will
+your traces show up in Galileo?
+
+{{< details summary="Click here to see the answer" >}}
+They'll land in a project named `default` and a log stream named `default`. Because `main.py`
+passes `os.getenv("GALILEO_PROJECT")` and `os.getenv("GALILEO_LOG_STREAM")`, those values are
+`None` when the variables are unset, and the Galileo SDK falls back to its built-in `default`
+project and `default` log stream.
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/3-add-langchain-callback.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/3-add-langchain-callback.md
@@ -14,14 +14,20 @@ pass a single callback in the **run config** when the compiled graph is streamed
 one trace per request, with a nested LLM span for each agent node (coordinator, flight, hotel,
 activity, and synthesizer).
 
-1. Add the callback import alongside the other LangChain imports in `main.py`:
+{{< exercise title="Add the LangChain callback" >}}
+
+{{< step title="Import the callback"  >}}
+
+Add the callback import alongside the other LangChain imports in `main.py`:
 
 ```python
 from galileo.handlers.langchain import GalileoCallback
 ```
 
-2. In `plan_travel_internal()`, create a callback and attach it to the run config passed to
-   `compiled_app.stream(...)`. The existing code should look something like this:
+{{< /step >}}
+
+{{< step title="Attach the callback to the graph run config"  >}}
+In `plan_travel_internal()`, create a callback and attach it to the run config passed to `compiled_app.stream(...)`. The existing code should look something like this:
 
 ```python
     workflow = build_workflow()
@@ -32,8 +38,7 @@ from galileo.handlers.langchain import GalileoCallback
         final_state = node_state
 ```
 
-   Update it to build a config that includes the Galileo callback (merging it with any existing
-   config the app already passes). This passes the execution of each node in the agent to Galileo:
+Update it to build a config that includes the Galileo callback (merging it with any existing config the app already passes). This passes the execution of each node in the agent to Galileo:
 
 ```python
     workflow = build_workflow()
@@ -48,8 +53,15 @@ from galileo.handlers.langchain import GalileoCallback
         final_state = node_state
 ```
 
-   Passing the callback at the graph level means it propagates to every node's `llm.invoke(...)`
-   call automatically. No further instrumentation is needed.
+Passing the callback at the graph level means it propagates to every node's `llm.invoke(...)` call automatically. No further instrumentation is needed.
+
+{{< /step >}}
+
+{{< /exercise >}}
+
+{{< checkpoint title="Knowledge Check" >}}
+
+Where do you attach the `GalileoCallback` in a LangGraph workflow?
 
 {{% notice title="Async workflows" style="blue" icon="info-circle" %}}
 If your app streams the graph asynchronously (`compiled_app.astream(...)`), use

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/3-add-langchain-callback.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/3-add-langchain-callback.md
@@ -1,0 +1,58 @@
+---
+title: Add the LangChain Callback
+linkTitle: 3. Add the LangChain Callback
+weight: 3
+time: 5 minutes
+---
+
+Galileo's `GalileoCallback` is a standard LangChain callback handler. When you attach it to a
+LangChain or LangGraph run, it automatically captures prompts, responses, model names, token usage,
+timing, and the nesting of each step.
+
+Because the travel planner is a **LangGraph** workflow, you don't need to edit every node. Instead,
+pass a single callback in the **run config** when the compiled graph is streamed. Galileo then records
+one trace per request, with a nested LLM span for each agent node (coordinator, flight, hotel,
+activity, and synthesizer).
+
+1. Add the callback import alongside the other LangChain imports in `main.py`:
+
+```python
+from galileo.handlers.langchain import GalileoCallback
+```
+
+2. In `plan_travel_internal()`, create a callback and attach it to the run config passed to
+   `compiled_app.stream(...)`. The existing code should look something like this:
+
+```python
+    workflow = build_workflow()
+    compiled_app = workflow.compile()
+
+    for step in compiled_app.stream(initial_state, config):
+        node_name, node_state = next(iter(step.items()))
+        final_state = node_state
+```
+
+   Update it to build a config that includes the Galileo callback (merging it with any existing
+   config the app already passes). This passes the execution of each node in the agent to Galileo:
+
+```python
+    workflow = build_workflow()
+    compiled_app = workflow.compile()
+
+    # One callback per request keeps each travel plan in its own trace.
+    callback = GalileoCallback()
+    run_config = {**config, "callbacks": [callback]}
+
+    for step in compiled_app.stream(initial_state, run_config):
+        node_name, node_state = next(iter(step.items()))
+        final_state = node_state
+```
+
+   Passing the callback at the graph level means it propagates to every node's `llm.invoke(...)`
+   call automatically. No further instrumentation is needed.
+
+{{% notice title="Async workflows" style="blue" icon="info-circle" %}}
+If your app streams the graph asynchronously (`compiled_app.astream(...)`), use
+`GalileoAsyncCallback` instead of `GalileoCallback`. The travel planner runs synchronously, so
+`GalileoCallback` is correct here.
+{{% /notice %}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/4-run-and-verify-trace.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/4-run-and-verify-trace.md
@@ -1,0 +1,106 @@
+---
+title: Run and Verify the Trace
+linkTitle: 4. Run and Verify the Trace
+weight: 4
+time: 5 minutes
+---
+
+Run the travel planner, send a request through it, then confirm the multi-agent trace landed in
+Galileo.
+
+1. Navigate to the base-app directory and activate the virtual environment:
+
+```bash
+cd ~/workshop/agentic-ai/base-app
+source .venv/bin/activate
+```
+
+2. Start the app:
+
+{{< tabs >}}
+{{% tab title="Script" %}}
+
+```bash
+python3 main.py
+```
+
+{{% /tab %}}
+{{% tab title="Example Output" %}}
+
+```text
+INFO:root:[INFO] Starting Flask server on http://0.0.0.0:8080
+ * Serving Flask app 'main'
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:8080
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+3. In a second terminal, send a travel-planning request. You should get the planned itinerary back,
+   confirming the workflow still runs end-to-end with the callback attached:
+
+{{< tabs >}}
+{{% tab title="Script" %}}
+
+```bash
+curl http://localhost:8080/travel/plan \
+  -H "Content-Type: application/json" \
+  -d '{
+    "origin": "Philadelphia",
+    "destination": "Florida",
+    "user_request": "Planning a two day long trip from Philadelphia to Florida. Looking for a boutique hotel, business-class flights and unique experiences.",
+    "travelers": 2
+  }'
+```
+
+{{% /tab %}}
+{{% tab title="Example Output" %}}
+
+```json
+{"activities_summary":"1. Everglades Airboat Tour – Explore unique wetlands and spot alligators.\n2. Kennedy Space Center Visit – Experience NASA exhibits and possibly a rocket launch.\n3. Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art.\n4. Key West Sunset Sail – Relax on a catamaran while watching a stunning sunset.\n5. Walt Disney World or Universal Studios – Enjoy world-class theme park attractions.\n6. Snorkeling at John Pennekamp Coral Reef – Dive into Florida’s only living coral reef.\n7. St. Augustine Historic District Tour – Walk through America’s oldest city with colonial charm.","agent_steps":[{"agent":"coordinator","status":"completed"},{"agent":"flight_specialist","status":"completed"},{"agent":"hotel_specialist","status":"completed"},{"agent":"activity_specialist","status":"completed"},{"agent":"plan_synthesizer","status":"completed"}],"departure":"2026-07-09","destination":"Florida","final_itinerary":"**Two-Day Florida Trip Itinerary (July 9 - July 11, 2026)**  \n*Origin: Philadelphia (PHL) | Destination: Miami, Florida*\n\n---\n\n### Flights  \n- **Departure:** July 9, 2026  \n- **From:** Philadelphia International Airport (PHL)  \n- **To:** Miami International Airport (MIA)  \n- **Airline:** American Airlines (Business Class)  \n- **Departure Time:** 9:00 AM  \n- **Arrival Time:** 12:00 PM  \n- **Notes:** Non-stop flight, approx. $220 per person  \n\n---\n\n### Accommodation  \n**The Betsy – South Beach, Miami Beach**  \n- Stylish beachfront boutique hotel with an art-focused design  \n- Amenities: Pool, rooftop deck, spa, multiple dining options  \n- Location: Ideal for exploring Miami’s vibrant culture and beach scene  \n\n---\n\n### Day 1: July 9, 2026  \n- **Afternoon:** Check-in at The Betsy and relax by the pool or rooftop deck  \n- **Evening:** Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art in South Beach  \n\n---\n\n### Day 2: July 10, 2026  \n- **Morning:** Everglades Airboat Tour – Explore unique wetlands and spot alligators on an exciting airboat ride  \n- **Afternoon:** Leisure time at the hotel or explore nearby Wynwood Arts District for its galleries and street art  \n- **Evening:** Dine at one of The Betsy’s fine dining options or enjoy a sunset walk along the beach  \n\n---\n\n### Return Flight  \n- **Date:** July 11, 2026 (morning or afternoon, to be booked as per preference)  \n- **From:** Miami International Airport (MIA)  \n- **To:** Philadelphia International Airport (PHL)  \n- **Airline:** American Airlines (Business Class)  \n\n---\n\n**Summary:**  \nFly business class from Philadelphia to Miami, stay at the elegant Betsy boutique hotel on South Beach, and enjoy unique experiences including a Miami Art Deco walking tour and an Everglades airboat adventure. This itinerary blends comfort, culture, and nature for a memorable two-day Florida getaway.  \n\nWould you like assistance with booking flights, hotel reservations, or arranging the activities?","flight_summary":"Here are some appealing flight options from Philadelphia (PHL) to Florida on 2026-07-09 for 2 travelers:\n\n1. Philadelphia (PHL) to Miami (MIA)\n   - Airline: American Airlines\n   - Departure: 09:00 AM\n   - Arrival: 12:00 PM\n   - Non-stop\n   - Approx. price: $220 per person\n\n2. Philadelphia (PHL) to Orlando (MCO)\n   - Airline: Delta Airlines\n   - Departure: 10:30 AM\n   - Arrival: 1:30 PM\n   - Non-stop\n   - Approx. price: $210 per person\n\n3. Philadelphia (PHL) to Tampa (TPA)\n   - Airline: Southwest Airlines\n   - Departure: 08:45 AM\n   - Arrival: 11:45 AM\n   - Non-stop\n   - Approx. price: $200 per person\n\nWould you like me to help you book any of these?","hotel_summary":"Here are three boutique hotel options in Florida for 2 travelers from July 9 to July 16, 2026:\n\n1. **The Betsy – South Beach, Miami Beach**\n   - Stylish beachfront boutique hotel with art-focused design.\n   - Amenities: Pool, rooftop deck, spa, and multiple dining options.\n   \n2. **The Don CeSar – St. Pete Beach**\n   - Iconic pink historic hotel with a luxurious boutique feel.\n   - Amenities: Private beach, pool, spa, and fine dining.\n\n3. **The Vagabond Hotel – Miami**\n   - Retro-chic boutique hotel with a vibrant, artistic vibe.\n   - Amenities: Pool, bar, and close to Wynwood Arts District.\n\nWould you like pricing and availability details for any of these?","origin":"Philadelphia","return_date":"2026-07-16","session_id":"2fa9ce38-0f1f-4015-8004-447b48b4546e","travellers":2}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+4. In the Galileo console (https://console.multitenant.galileocloud.io/splunkse) , open the project and log stream your traces landed in. If you uncommented
+   `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` in your `.env`, that's `Workshop19Galileo` /
+   `TravelPlanner`; otherwise it's the `default` project and `default` log stream.
+
+5. Open the most recent trace. Because the callback was attached at the graph level, you should see a
+   single trace for the request containing a nested LLM span for each agent node:
+
+   * `coordinator`
+   * `flight_specialist`
+   * `hotel_specialist`
+   * `activity_specialist`
+   * `plan_synthesizer`
+
+6. Expand any span and verify it captured the **system and human messages**, the **model response**,
+   the **model name**, **token counts**, and **latency**.
+
+{{% notice title="No trace showing up?" style="orange" icon="exclamation-triangle" %}}
+
+* Confirm `GALILEO_API_KEY` is set in the environment the app runs in (it loads `.env` via
+  `load_dotenv()`).
+* Confirm you're viewing the right project and log stream: the values from `GALILEO_PROJECT` /
+  `GALILEO_LOG_STREAM` if you set them, or `default` / `default` if you didn't.
+* If you don't see the project, you likely don't have the correct permissions.
+* Check the app logs for Galileo errors in the bash where `python3 main.py` is running.
+* Confirm that you are in the `splunkse` organization in the top left of the web page.
+
+{{% /notice %}}
+
+### Knowledge Check
+
+A single travel-planning request produces one trace containing five nested LLM spans, rather
+than five separate traces. Why?
+
+{{< details summary="Click here to see the answer" >}}
+Because the whole LangGraph workflow runs as **one root run** per request, and the callback was
+attached to that run's config. LangGraph executes the five nodes (coordinator, flight, hotel,
+activity, synthesizer) within that single run, so each node's `llm.invoke(...)` becomes a child
+span under the same trace. If you instead created a new callback and a new run for each node, you'd
+get five disconnected traces (and sessions) and lose the end-to-end view of the request.
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/4-run-and-verify-trace.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/4-run-and-verify-trace.md
@@ -5,19 +5,24 @@ weight: 4
 time: 5 minutes
 ---
 
-Run the travel planner, send a request through it, then confirm the multi-agent trace landed in
-Galileo.
+Run the travel planner, send a request through it, then confirm the multi-agent trace landed in Galileo.
 
-1. Navigate to the base-app directory and activate the virtual environment:
+{{< exercise title="Run the app and verify the trace" >}}
+
+{{< step title="Active Environment" >}}
+Navigate to the base-app directory and activate the virtual environment:
 
 ```bash
 cd ~/workshop/agentic-ai/base-app
 source .venv/bin/activate
 ```
 
-2. Start the app:
+{{< /step >}}
 
-{{< tabs >}}
+{{< step title="Run the app"  >}}
+Start the app:
+
+{{< tabs id="run-app" >}}
 {{% tab title="Script" %}}
 
 ```bash
@@ -37,10 +42,12 @@ INFO:root:[INFO] Starting Flask server on http://0.0.0.0:8080
 {{% /tab %}}
 {{< /tabs >}}
 
-3. In a second terminal, send a travel-planning request. You should get the planned itinerary back,
-   confirming the workflow still runs end-to-end with the callback attached:
+{{< /step >}}
 
-{{< tabs >}}
+{{< step title="Send a request to the app"  >}}
+In a second terminal, send a travel-planning request. You should get the planned itinerary back, confirming the workflow still runs end-to-end with the callback attached:
+
+{{< tabs id="send-request" >}}
 {{% tab title="Script" %}}
 
 ```bash
@@ -58,29 +65,70 @@ curl http://localhost:8080/travel/plan \
 {{% tab title="Example Output" %}}
 
 ```json
-{"activities_summary":"1. Everglades Airboat Tour – Explore unique wetlands and spot alligators.\n2. Kennedy Space Center Visit – Experience NASA exhibits and possibly a rocket launch.\n3. Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art.\n4. Key West Sunset Sail – Relax on a catamaran while watching a stunning sunset.\n5. Walt Disney World or Universal Studios – Enjoy world-class theme park attractions.\n6. Snorkeling at John Pennekamp Coral Reef – Dive into Florida’s only living coral reef.\n7. St. Augustine Historic District Tour – Walk through America’s oldest city with colonial charm.","agent_steps":[{"agent":"coordinator","status":"completed"},{"agent":"flight_specialist","status":"completed"},{"agent":"hotel_specialist","status":"completed"},{"agent":"activity_specialist","status":"completed"},{"agent":"plan_synthesizer","status":"completed"}],"departure":"2026-07-09","destination":"Florida","final_itinerary":"**Two-Day Florida Trip Itinerary (July 9 - July 11, 2026)**  \n*Origin: Philadelphia (PHL) | Destination: Miami, Florida*\n\n---\n\n### Flights  \n- **Departure:** July 9, 2026  \n- **From:** Philadelphia International Airport (PHL)  \n- **To:** Miami International Airport (MIA)  \n- **Airline:** American Airlines (Business Class)  \n- **Departure Time:** 9:00 AM  \n- **Arrival Time:** 12:00 PM  \n- **Notes:** Non-stop flight, approx. $220 per person  \n\n---\n\n### Accommodation  \n**The Betsy – South Beach, Miami Beach**  \n- Stylish beachfront boutique hotel with an art-focused design  \n- Amenities: Pool, rooftop deck, spa, multiple dining options  \n- Location: Ideal for exploring Miami’s vibrant culture and beach scene  \n\n---\n\n### Day 1: July 9, 2026  \n- **Afternoon:** Check-in at The Betsy and relax by the pool or rooftop deck  \n- **Evening:** Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art in South Beach  \n\n---\n\n### Day 2: July 10, 2026  \n- **Morning:** Everglades Airboat Tour – Explore unique wetlands and spot alligators on an exciting airboat ride  \n- **Afternoon:** Leisure time at the hotel or explore nearby Wynwood Arts District for its galleries and street art  \n- **Evening:** Dine at one of The Betsy’s fine dining options or enjoy a sunset walk along the beach  \n\n---\n\n### Return Flight  \n- **Date:** July 11, 2026 (morning or afternoon, to be booked as per preference)  \n- **From:** Miami International Airport (MIA)  \n- **To:** Philadelphia International Airport (PHL)  \n- **Airline:** American Airlines (Business Class)  \n\n---\n\n**Summary:**  \nFly business class from Philadelphia to Miami, stay at the elegant Betsy boutique hotel on South Beach, and enjoy unique experiences including a Miami Art Deco walking tour and an Everglades airboat adventure. This itinerary blends comfort, culture, and nature for a memorable two-day Florida getaway.  \n\nWould you like assistance with booking flights, hotel reservations, or arranging the activities?","flight_summary":"Here are some appealing flight options from Philadelphia (PHL) to Florida on 2026-07-09 for 2 travelers:\n\n1. Philadelphia (PHL) to Miami (MIA)\n   - Airline: American Airlines\n   - Departure: 09:00 AM\n   - Arrival: 12:00 PM\n   - Non-stop\n   - Approx. price: $220 per person\n\n2. Philadelphia (PHL) to Orlando (MCO)\n   - Airline: Delta Airlines\n   - Departure: 10:30 AM\n   - Arrival: 1:30 PM\n   - Non-stop\n   - Approx. price: $210 per person\n\n3. Philadelphia (PHL) to Tampa (TPA)\n   - Airline: Southwest Airlines\n   - Departure: 08:45 AM\n   - Arrival: 11:45 AM\n   - Non-stop\n   - Approx. price: $200 per person\n\nWould you like me to help you book any of these?","hotel_summary":"Here are three boutique hotel options in Florida for 2 travelers from July 9 to July 16, 2026:\n\n1. **The Betsy – South Beach, Miami Beach**\n   - Stylish beachfront boutique hotel with art-focused design.\n   - Amenities: Pool, rooftop deck, spa, and multiple dining options.\n   \n2. **The Don CeSar – St. Pete Beach**\n   - Iconic pink historic hotel with a luxurious boutique feel.\n   - Amenities: Private beach, pool, spa, and fine dining.\n\n3. **The Vagabond Hotel – Miami**\n   - Retro-chic boutique hotel with a vibrant, artistic vibe.\n   - Amenities: Pool, bar, and close to Wynwood Arts District.\n\nWould you like pricing and availability details for any of these?","origin":"Philadelphia","return_date":"2026-07-16","session_id":"2fa9ce38-0f1f-4015-8004-447b48b4546e","travellers":2}
+{
+  "activities_summary": "1. Everglades Airboat Tour – Explore unique wetlands and spot alligators.\n2. Kennedy Space Center Visit – Experience NASA exhibits and possibly a rocket launch.\n3. Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art.\n4. Key West Sunset Sail – Relax on a catamaran while watching a stunning sunset.\n5. Walt Disney World or Universal Studios – Enjoy world-class theme park attractions.\n6. Snorkeling at John Pennekamp Coral Reef – Dive into Florida’s only living coral reef.\n7. St. Augustine Historic District Tour – Walk through America’s oldest city with colonial charm.",
+  "agent_steps": [
+    {
+      "agent": "coordinator",
+      "status": "completed"
+    },
+    {
+      "agent": "flight_specialist",
+      "status": "completed"
+    },
+    {
+      "agent": "hotel_specialist",
+      "status": "completed"
+    },
+    {
+      "agent": "activity_specialist",
+      "status": "completed"
+    },
+    {
+      "agent": "plan_synthesizer",
+      "status": "completed"
+    }
+  ],
+  "departure": "2026-07-09",
+  "destination": "Florida",
+  "final_itinerary": "**Two-Day Florida Trip Itinerary (July 9 - July 11, 2026)**  \n*Origin: Philadelphia (PHL) | Destination: Miami, Florida*\n\n---\n\n### Flights  \n- **Departure:** July 9, 2026  \n- **From:** Philadelphia International Airport (PHL)  \n- **To:** Miami International Airport (MIA)  \n- **Airline:** American Airlines (Business Class)  \n- **Departure Time:** 9:00 AM  \n- **Arrival Time:** 12:00 PM  \n- **Notes:** Non-stop flight, approx. $220 per person  \n\n---\n\n### Accommodation  \n**The Betsy – South Beach, Miami Beach**  \n- Stylish beachfront boutique hotel with an art-focused design  \n- Amenities: Pool, rooftop deck, spa, multiple dining options  \n- Location: Ideal for exploring Miami’s vibrant culture and beach scene  \n\n---\n\n### Day 1: July 9, 2026  \n- **Afternoon:** Check-in at The Betsy and relax by the pool or rooftop deck  \n- **Evening:** Miami Art Deco Walking Tour – Discover iconic architecture and vibrant street art in South Beach  \n\n---\n\n### Day 2: July 10, 2026  \n- **Morning:** Everglades Airboat Tour – Explore unique wetlands and spot alligators on an exciting airboat ride  \n- **Afternoon:** Leisure time at the hotel or explore nearby Wynwood Arts District for its galleries and street art  \n- **Evening:** Dine at one of The Betsy’s fine dining options or enjoy a sunset walk along the beach  \n\n---\n\n### Return Flight  \n- **Date:** July 11, 2026 (morning or afternoon, to be booked as per preference)  \n- **From:** Miami International Airport (MIA)  \n- **To:** Philadelphia International Airport (PHL)  \n- **Airline:** American Airlines (Business Class)  \n\n---\n\n**Summary:**  \nFly business class from Philadelphia to Miami, stay at the elegant Betsy boutique hotel on South Beach, and enjoy unique experiences including a Miami Art Deco walking tour and an Everglades airboat adventure. This itinerary blends comfort, culture, and nature for a memorable two-day Florida getaway.  \n\nWould you like assistance with booking flights, hotel reservations, or arranging the activities?",
+  "flight_summary": "Here are some appealing flight options from Philadelphia (PHL) to Florida on 2026-07-09 for 2 travelers:\n\n1. Philadelphia (PHL) to Miami (MIA)\n   - Airline: American Airlines\n   - Departure: 09:00 AM\n   - Arrival: 12:00 PM\n   - Non-stop\n   - Approx. price: $220 per person\n\n2. Philadelphia (PHL) to Orlando (MCO)\n   - Airline: Delta Airlines\n   - Departure: 10:30 AM\n   - Arrival: 1:30 PM\n   - Non-stop\n   - Approx. price: $210 per person\n\n3. Philadelphia (PHL) to Tampa (TPA)\n   - Airline: Southwest Airlines\n   - Departure: 08:45 AM\n   - Arrival: 11:45 AM\n   - Non-stop\n   - Approx. price: $200 per person\n\nWould you like me to help you book any of these?",
+  "hotel_summary": "Here are three boutique hotel options in Florida for 2 travelers from July 9 to July 16, 2026:\n\n1. **The Betsy – South Beach, Miami Beach**\n   - Stylish beachfront boutique hotel with art-focused design.\n   - Amenities: Pool, rooftop deck, spa, and multiple dining options.\n   \n2. **The Don CeSar – St. Pete Beach**\n   - Iconic pink historic hotel with a luxurious boutique feel.\n   - Amenities: Private beach, pool, spa, and fine dining.\n\n3. **The Vagabond Hotel – Miami**\n   - Retro-chic boutique hotel with a vibrant, artistic vibe.\n   - Amenities: Pool, bar, and close to Wynwood Arts District.\n\nWould you like pricing and availability details for any of these?",
+  "origin": "Philadelphia",
+  "return_date": "2026-07-16",
+  "session_id": "2fa9ce38-0f1f-4015-8004-447b48b4546e",
+  "travellers": 2
+}
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
-4. In the Galileo console (https://console.multitenant.galileocloud.io/splunkse) , open the project and log stream your traces landed in. If you uncommented
+{{< /step >}}
+
+{{< step title="Verify the trace in Galileo" >}}
+
+In the Galileo console (https://console.multitenant.galileocloud.io/splunkse) , open the project and log stream your traces landed in. If you uncommented
    `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` in your `.env`, that's `Workshop19Galileo` /
    `TravelPlanner`; otherwise it's the `default` project and `default` log stream.
+{{< /step >}}
 
-5. Open the most recent trace. Because the callback was attached at the graph level, you should see a
+{{< step title="Find the trace" >}}
+Open the most recent trace. Because the callback was attached at the graph level, you should see a
    single trace for the request containing a nested LLM span for each agent node:
 
-   * `coordinator`
-   * `flight_specialist`
-   * `hotel_specialist`
-   * `activity_specialist`
-   * `plan_synthesizer`
+* `coordinator`
+* `flight_specialist`
+* `hotel_specialist`
+* `activity_specialist`
+* `plan_synthesizer`
 
-6. Expand any span and verify it captured the **system and human messages**, the **model response**,
-   the **model name**, **token counts**, and **latency**.
+{{< /step >}}
 
-{{% notice title="No trace showing up?" style="orange" icon="exclamation-triangle" %}}
+{{< step title="Inspect the spans" >}}
+Expand any span and verify it captured the **system and human messages**, the **model response**, the **model name**, **token counts**, and **latency**.
+
+{{% notice title="No trace showing up?" style="tip" icon="exclamation-triangle" %}}
 
 * Confirm `GALILEO_API_KEY` is set in the environment the app runs in (it loads `.env` via
   `load_dotenv()`).
@@ -91,8 +139,11 @@ curl http://localhost:8080/travel/plan \
 * Confirm that you are in the `splunkse` organization in the top left of the web page.
 
 {{% /notice %}}
+{{< /step >}}
 
-### Knowledge Check
+{{< /exercise >}}
+
+{{< checkpoint title="Knowledge Check" >}}
 
 A single travel-planning request produces one trace containing five nested LLM spans, rather
 than five separate traces. Why?

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/5-wrap-up.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/5-wrap-up.md
@@ -1,0 +1,28 @@
+---
+title: Wrap-up
+linkTitle: 5. Wrap-up
+weight: 5
+time: 20 minutes
+---
+
+You took the workshop 18 multi-agent travel planner and instrumented it with Galileo (Splunk Agent Observability) by adding just
+two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
+With that, every agent node's LLM call now appears as a nested span in a single Galileo trace per
+request — no per-node changes required and very low maintenance.
+
+You now have the same workload traced in **two** observability tools (Splunk Observability Cloud from
+workshop 18, and Galileo here), which is a useful basis for comparison.
+
+Next, we're going to expand on this by:
+
+* Adding Galileo metrics (for example, `Context Adherence`) to the captured traces.
+* Working through the features that help Galileo support better observability of agents.
+* Leveraging powerful features like Signals.
+* Using a dedicated `GalileoLogger(project=..., log_stream=...)` to route specific runs to different
+  log streams.
+* Adding more complexity to our agents.
+
+## References
+
+* [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
+* [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/5-wrap-up.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/5-wrap-up.md
@@ -5,24 +5,23 @@ weight: 5
 time: 20 minutes
 ---
 
-You took the workshop 18 multi-agent travel planner and instrumented it with Galileo (Splunk Agent Observability) by adding just
-two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
-With that, every agent node's LLM call now appears as a nested span in a single Galileo trace per
-request — no per-node changes required and very low maintenance.
+You took the [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) multi-agent travel planner and instrumented it with Galileo (Splunk Agent Observability) by adding just two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
 
-You now have the same workload traced in **two** observability tools (Splunk Observability Cloud from
-workshop 18, and Galileo here), which is a useful basis for comparison.
+With that, every agent node's LLM call now appears as a nested span in a single Galileo trace per request — no per-node changes required and very low maintenance.
+
+You now have the same workload traced in **two** observability tools (Splunk Observability Cloud from [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/), and Galileo here), which is a useful basis for comparison.
 
 Next, we're going to expand on this by:
 
 * Adding Galileo metrics (for example, `Context Adherence`) to the captured traces.
 * Working through the features that help Galileo support better observability of agents.
 * Leveraging powerful features like Signals.
-* Using a dedicated `GalileoLogger(project=..., log_stream=...)` to route specific runs to different
-  log streams.
+* Using a dedicated `GalileoLogger(project=..., log_stream=...)` to route specific runs to different log streams.
 * Adding more complexity to our agents.
 
 ## References
 
 * [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
 * [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)
+
+{{< checkpoint title="Workshop complete -- **nice work!**" >}}

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/_index.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/_index.md
@@ -1,0 +1,32 @@
+---
+title: Galileo Instrumentation for LangChain Apps
+linkTitle: Galileo Instrumentation for LangChain Apps
+weight: 19
+layout: chapter
+time: 40 minutes
+authors: ["Sam Goldfield"]
+description: Add Galileo (Splunk Agent Observability) tracing to a LangChain app and inspect traces in the console UI.
+draft: false
+hidden: false
+aliases:
+  - /ninja-workshops/19-agent-observability-galileo/
+product: "Observability Cloud"
+---
+
+This workshop picks up after workshop 18 and shows the fastest path to instrumenting a LangChain app with Galileo.
+
+You will reuse the **multi-agent travel planner** from workshop 18. It is a Flask API backed by a LangGraph
+workflow whose nodes (coordinator, flight specialist, hotel specialist, activity specialist, and
+synthesizer) each call an LLM through LangChain. Instead of sending its telemetry to Splunk
+Observability Cloud, you'll trace it with Galileo (Splunk Agent Observability).
+
+You will:
+
+* Install the Galileo SDK and set required environment variables.
+* Add Galileo context initialization and a single LangChain callback to the travel planner.
+* Run a real travel-planning request and verify the full multi-agent trace in the Galileo console.
+
+Primary references:
+
+* [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
+* [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)

--- a/content/en/ninja-workshops/ai/19-agent-observability-galileo/_index.md
+++ b/content/en/ninja-workshops/ai/19-agent-observability-galileo/_index.md
@@ -15,18 +15,22 @@ product: "Observability Cloud"
 
 This workshop picks up after workshop 18 and shows the fastest path to instrumenting a LangChain app with Galileo.
 
-You will reuse the **multi-agent travel planner** from workshop 18. It is a Flask API backed by a LangGraph
+You will reuse the **multi-agent travel planner** from workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/). It is a Flask API backed by a LangGraph
 workflow whose nodes (coordinator, flight specialist, hotel specialist, activity specialist, and
 synthesizer) each call an LLM through LangChain. Instead of sending its telemetry to Splunk
 Observability Cloud, you'll trace it with Galileo (Splunk Agent Observability).
 
-You will:
+{{< objectives title="Objectives" >}}
 
 * Install the Galileo SDK and set required environment variables.
 * Add Galileo context initialization and a single LangChain callback to the travel planner.
 * Run a real travel-planning request and verify the full multi-agent trace in the Galileo console.
 
-Primary references:
+{{< /objectives >}}
+
+{{% notice style="info" title="Primary references" %}}
 
 * [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
 * [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)
+
+{{% /notice %}}


### PR DESCRIPTION
## Summary

Adds a 40 min ninja workshop that follows on from workshop 18 (Monitoring Agentic AI Applications). It reuses the workshop 18 LangGraph travel-planner app and instruments it with **Galileo (Splunk Agent Observability)** tracing instead of (or alongside) Splunk Observability Cloud.

Content lives at `content/en/ninja-workshops/ai/19-agent-observability-galileo/`.

## References

- [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
- [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)