### PR TITLE
Fix section numbering

### DIFF
--- a/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas.md
+++ b/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas.md
@@ -1,7 +1,7 @@
 ---
 title: Splunk APM, Lambda Functions and Traces, Again!
-linkTitle: 6. Updated Lambdas in Splunk APM
-weight: 6
+linkTitle: 7. Updated Lambdas in Splunk APM
+weight: 7
 ---
 
 In order to see the result of our context propagation outside of the logs, we'll once again consult the [Splunk APM UI](https://app.us1.signalfx.com/#/apm).


### PR DESCRIPTION
## Summary

Fix section numbering off by 1 issue caused by having duplicate section 4.

Fixes # (optional — link an issue / ticket)

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** e.g. `ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
