### PR TITLE
Update 7-updated-lambdas.md typos

### DIFF
--- a/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas.md
+++ b/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas.md
@@ -76,9 +76,9 @@ Now that we have seen that, it's time to clean up.
 
 ## Stop the messages
 
-The resources we deployed as part of this auto-instrumenation exercise need to be cleaned. Likewise, the script that was generating traffice against our `producer-lambda` endpoint needs to be stopped, if it's still running. Follow the below steps to clean up.
+The resources we deployed as part of this instrumenation exercise need to be cleaned up. Likewise, the script that was generating traffic against our `producer-lambda` endpoint needs to be stopped, if it's still running. Follow the below steps to clean up resources.
 
-* If the `send_message.py` script is still running, stop it with the follwing commands:
+* If the `send_message.py` script is still running, stop it with the following commands:
 
 ```bash
 fg
@@ -88,8 +88,6 @@ fg
 * Next you can hit `[CONTROL-C]` to kill the process.
 
 ## Destroy all AWS resources
-
-Terraform is great at managing the state of our resources individually, and as a deployment. It can even update deployed resources with any changes to their definitions. But to start afresh, we will destroy the resources and redeploy them as part of the manual instrumentation portion of this workshop.
 
 Please follow these steps to destroy your resources:
 


### PR DESCRIPTION
## Summary

Fixed typos, removed incorrect leftover duplicate boilerplate from autoinstrumentation section.

Fixes # (optional — link an issue / ticket)

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** e.g. `ninja-workshops/instrumentation/6-lambda-kinesis/7-updated-lambdas/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
