### PR TITLE
Bump theme to v0.13.8

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,7 +3,7 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.7/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.8/assets/*"
    ]
   }
  }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.7 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.8 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.13.7 h1:GYhnkasTQ8HFbvcJCsSLf11RnXHby6ZxHieiVFL1m+A=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.7/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.8 h1:C++mTaNTfrlCe056lRMkt7VorAUsPphW5msLxNS5VuE=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.8/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
Picks up the tabs shortcode update: tab buckets now support an explicit `id=` (or `key=`) attribute for stable hand-authored keys and fall back to a `.Position + .Ordinal` slug otherwise, which keeps separate `{{% tabs %}}` blocks from colliding in `.Page.Store` when one of them is nested inside another percent shortcode (the fix from v0.13.7, now with the optional explicit-id escape hatch).

* go.mod / go.sum: v0.13.7 -> v0.13.8
* assets/jsconfig.json: IntelliSense path catches up to v0.13.8
