### PR TITLE
Pass GITHUB_TOKEN explicitly to the Publish GitHub release step

### DIFF
--- a/.github/workflows/deploy-workshop.yml
+++ b/.github/workflows/deploy-workshop.yml
@@ -129,3 +129,4 @@ jobs:
         with:
           name: v${{ steps.bumpversion.outputs.tag_name }}
           tag_name: v${{ steps.bumpversion.outputs.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`softprops/action-gh-release@v2` was relying on the implicit `GITHUB_TOKEN` env var to authenticate against the API. After a recent v2 release that started failing with HTTP 401 ("Requires authentication"), tanking the v6.94 release run after the bump, build, and gh-pages deploy had already succeeded.

Pass `token: ${{ secrets.GITHUB_TOKEN }}` directly via `with:` so the action authenticates regardless of whether it still reads the env var. Matches the documented usage on the action's README.
