### PR TITLE
Fixed typo in 'peek'

### DIFF
--- a/content/en/scenarios/debug-problems/tagging/2-what-are-tags.md
+++ b/content/en/scenarios/debug-problems/tagging/2-what-are-tags.md
@@ -30,7 +30,7 @@ Tags are essential for an application to be truly observable. As we saw with our
 
 Tags add the context to the traces to help us understand why some users get a great experience and others don't.  And powerful features in **Splunk Observability Cloud** utilize tags to help you jump quickly to root cause.
 
-## Sneak Peak: Tag Spotlight
+## Sneak Peek: Tag Spotlight
 
 **Tag Spotlight** uses tags to discover trends that contribute to high latency or error rates:
 
@@ -42,7 +42,7 @@ Splunk has analyzed all of the tags included as part of traces that involve the 
 
 It tells us very quickly whether some tag values have more errors than others.
 
-If we look at the version tag, we can see that version 350.10 of the service has a 100% error rate, whereas version 350.9 of the service has no errors at all:
+If we look at the version tag, we can see that version `350.10` of the service has a 100% error rate, whereas version `350.9` of the service has no errors at all:
 
 ![Tag Spotlight Preview](../images/tag_spotlight_preview_details.png)
 


### PR DESCRIPTION
## Summary

Fixed typo in 'peek'. Wrapped version tags for emphasis.

## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** e.g. `observability-workshop/en/scenarios/debug-problems/tagging/2-what-are-tags/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus

## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
