### PR TITLE
Update typos in 3-auto-instrumentation.md

### DIFF
--- a/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/3-auto-instrumentation.md
+++ b/content/en/ninja-workshops/instrumentation/6-lambda-kinesis/3-auto-instrumentation.md
@@ -63,7 +63,7 @@ By using these environment variables, we are configuring our auto-instrumentatio
 
 ```bash
 SPLUNK_ACCESS_TOKEN = var.o11y_access_token
-SPLUNK_ACCESS_TOKEN = var.o11y_realm
+SPLUNK_REALM = var.o11y_realm
 ```
 
 * We are also setting variables that help OpenTelemetry identify our function/service, as well as the environment/application it is a part of.
@@ -82,7 +82,7 @@ AWS_LAMBDA_EXEC_WRAPPER - "/opt/nodejs-otel-handler"
 * In the case of the `producer-lambda` function, we are setting an environment variable to let the function know what Kinesis Stream to put our record to.
 
 ```bash
-KINESIS_STREAM = aws_kinesis_stream.lambda_streamer.name
+KINESIS_STREAM = aws_kinesis_stream.lambda_stream.name
 ```
 
 * These values are sourced from the environment variables we set in the Prerequisites section, as well as resources that will be deployed as a part of this Terraform configuration file.


### PR DESCRIPTION
## Summary

Fix incorrect duplicate reference to SPLUNK_ACCESS_TOKEN. Fix value associated with KINESIS_STREAM variable.


## Type of change

- [ ] New workshop
- [ ] New chapter or page in an existing workshop
- [X] Content edits (clarity, correctness, polish) to existing pages
- [ ] Restructure / reorganize (move, split, merge, renumber)
- [ ] URL change — `aliases:` added for any renamed or moved page
- [ ] Image / screenshot refresh
- [ ] Translation sync (`content/en` ↔ `content/ja`)
- [ ] Content removal / archival
- [ ] Theme bump or shortcode / layout adoption
- [ ] Frontmatter-only changes (weight, `draft`, `hidden`, `archetype`, …)
- [ ] Lint / formatting cleanup (low-risk, scan-approve)
- [ ] CI / build / tooling
- [ ] Bug fix (broken link, busted shortcode, etc.)
- [ ] Other — describe:

## What's affected

- **Workshop(s) / area:** e.g. `ninja-workshops/instrumentation/6-lambda-kinesis/3-auto-instrumentation/`
- **Languages:** [X] `content/en` &nbsp;&nbsp; [ ] `content/ja`

## Reviewer focus


## Screenshots / preview

N/A

## Verification

- [ ] `hugo` builds cleanly (no warnings or errors)
- [ ] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [ ] Any new images have meaningful alt text
- [ ] No TODO image placeholders left unintentionally
- [ ] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [ ] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
