### PR TITLE
Tomcat update 18244079

### DIFF
--- a/content/en/ninja-workshops/appdynamics/17-appd-ingest/1-overview/_index.md
+++ b/content/en/ninja-workshops/appdynamics/17-appd-ingest/1-overview/_index.md
@@ -85,7 +85,7 @@ These attributes enable **global data links** clickable links on Splunk Observab
 
 ## Prerequisites
 
-Your workshop instance comes pre-configured with the tools you need:
+Your workshop instance comes pre-configured with the tools you need (or spin up your own with this [Splunk Show instance!](https://show.splunk.com/template/428/)):
 
 | Requirement | Status on Workshop Instance |
 |---|---|

--- a/workshop/appd/app/pom.xml
+++ b/workshop/appd/app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.15</version>
         <relativePath/>
     </parent>
 

--- a/workshop/appd/collector-config.yaml
+++ b/workshop/appd/collector-config.yaml
@@ -27,10 +27,6 @@ extensions:
       endpoint: "${SPLUNK_API_URL}"
       # Use instead when sending to gateway
       #endpoint: "${SPLUNK_GATEWAY_URL}"
-  smartagent:
-    bundleDir: "${SPLUNK_BUNDLE_DIR}"
-    collectd:
-      configDir: "${SPLUNK_COLLECTD_DIR}"
   zpages:
     #endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
     expvar:
@@ -229,7 +225,7 @@ service:
               prometheus:
                 host: '127.0.0.1'
                 port: 8888
-  extensions: [headers_setter, health_check, http_forwarder, zpages, smartagent]
+  extensions: [headers_setter, health_check, http_forwarder, zpages]
   pipelines:
     traces:
       receivers: [jaeger, otlp, zipkin]


### PR DESCRIPTION
## Summary

What this PR changes and why. One or two sentences.
fixes #VULN-84947 related to old tomcat version. 
- Updated dependency pulling in tomcat
- Validated newer version of tomcat in deploy
- Validated working for the workshop flow

## Type of change

- [X] Bug fix (broken link, busted shortcode, etc.)
## Verification

- [X] `hugo` builds cleanly (no warnings or errors)ntmatter added for any renamed / moved pages
