### PR TITLE
Fix HPA workshop sort order in ninja infrastructure

### DIFF
--- a/content/en/ninja-workshops/infrastructure/1-hpa/_index.md
+++ b/content/en/ninja-workshops/infrastructure/1-hpa/_index.md
@@ -2,7 +2,7 @@
 title: Monitoring Horizontal Pod Autoscaling in Kubernetes
 linkTitle: Horizontal Pod Autoscaling
 description: Monitor Kubernetes HPA with the Splunk OpenTelemetry Collector — watch scale-up and scale-down events as they happen.
-weight: 2
+weight: 1
 authors: ["Robert Castley"]
 time: 45 minutes
 aliases:


### PR DESCRIPTION
## Summary
- update `content/en/ninja-workshops/infrastructure/1-hpa/_index.md` to set `weight: 1`
- align infrastructure workshop ordering with the renamed `1-hpa` folder
- ensure the HPA workshop appears in the expected position in Hugo navigation

## Test plan
- [ ] run `hugo server`
- [ ] open `/en/ninja-workshops/infrastructure/` and verify **HPA** appears first
- [ ] confirm no broken navigation links in the infrastructure section

Made with [Cursor](https://cursor.com)