### PR TITLE
Update module metadata and ignore generated jsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ workshop/ninja/advanced-otel/1-agent/send-trace.sh
 content/en/conf/1-advanced-collector/1-agent-gateway/old.zip
 observability-workshop.sln
 workshop/appd/app/target/
+assets/jsconfig.json

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -1,9 +1,8 @@
 {
  "compilerOptions": {
-  "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.10/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.11/assets/*"
    ]
   }
  }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.10 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.11 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/splunk/hugo-theme-splunk-workshop v0.13.10 h1:7Oeyw5N+hJ8GvMAhVAktraaDlxe25XDavJeEUX29//c=
 github.com/splunk/hugo-theme-splunk-workshop v0.13.10/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.11 h1:dalTJRJAnmw0KNG6dXI19KlbxdSWP1O4/8o+alKdbKY=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.11/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
## Summary
- bump theme module reference from `v0.13.10` to `v0.13.11` in `go.mod` and `go.sum`
- add `assets/jsconfig.json` to `.gitignore` to avoid churn from machine-local cache paths
- include the current `assets/jsconfig.json` update produced by module resolution

## Test plan
- [x] run `hugo --quiet`
- [x] run `hugo mod graph` and confirm module resolution succeeds

Made with [Cursor](https://cursor.com)