### PR TITLE
Update S4R aliases and bump theme module to v0.13.12

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -2,7 +2,7 @@
  "compilerOptions": {
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.11/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.12/assets/*"
    ]
   }
  }

--- a/content/en/splunk4rookies/financial-services-observability-cloud/_index.md
+++ b/content/en/splunk4rookies/financial-services-observability-cloud/_index.md
@@ -4,7 +4,7 @@ weight: 3
 authors: ["Robert Castley", "Pieter Hagen", "Jeremy Hicks", "Deepti Bhutani"]
 time: 30 minutes
 aliases:
-  - /en/s4r/
+  - /s4r/financial-services-observability-cloud/
 description: For financial services teams. See how Splunk Observability Cloud delivers real-time visibility across the FSI digital ecosystem in a 30-minute hands-on session.
 params:
   images:

--- a/content/en/splunk4rookies/observability-cloud/_index.md
+++ b/content/en/splunk4rookies/observability-cloud/_index.md
@@ -4,7 +4,7 @@ weight: 2
 authors: ["Robert Castley", "Pieter Hagen"]
 time: 90 minutes
 aliases:
-  - /en/s4r/
+  - /s4r/observability-cloud/
 description: Three hours, hands-on. Explore the full Splunk Observability Cloud platform end-to-end against a live microservices app and see the features that differentiate it from other observability tools.
 params:
   images:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.11 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.12 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/splunk/hugo-theme-splunk-workshop v0.13.10 h1:7Oeyw5N+hJ8GvMAhVAktraa
 github.com/splunk/hugo-theme-splunk-workshop v0.13.10/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
 github.com/splunk/hugo-theme-splunk-workshop v0.13.11 h1:dalTJRJAnmw0KNG6dXI19KlbxdSWP1O4/8o+alKdbKY=
 github.com/splunk/hugo-theme-splunk-workshop v0.13.11/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.12 h1:f2ll1pg9MlM7ajgmJ7eNLGatVIQz8wY7MGuKUlHwfXo=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.12/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
## Summary
- update Splunk4Rookies aliases to point to workshop-specific short URLs for `observability-cloud` and `financial-services-observability-cloud`
- bump `github.com/splunk/hugo-theme-splunk-workshop` from `v0.13.11` to `v0.13.12`
- refresh generated module metadata in `assets/jsconfig.json` to match the resolved theme version

## Test plan
- [x] run `hugo --quiet`
- [ ] open `/en/splunk4rookies/` and verify both cards route via their updated aliases

Made with [Cursor](https://cursor.com)