### PR TITLE
Bump hugo-theme-splunk-workshop to v0.13.13

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -2,7 +2,7 @@
  "compilerOptions": {
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.12/assets/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/splunk/hugo-theme-splunk-workshop@v0.13.13/assets/*"
    ]
   }
  }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.12 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.13 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.13.10 h1:7Oeyw5N+hJ8GvMAhVAktraaDlxe25XDavJeEUX29//c=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.10/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.11 h1:dalTJRJAnmw0KNG6dXI19KlbxdSWP1O4/8o+alKdbKY=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.11/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.12 h1:f2ll1pg9MlM7ajgmJ7eNLGatVIQz8wY7MGuKUlHwfXo=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.12/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.13 h1:adfwT32zsJWS8fc2Yb7ECVS1Bd8OYizZG2OdnbDYwwE=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.13/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
## Summary
- bump `github.com/splunk/hugo-theme-splunk-workshop` from `v0.13.12` to `v0.13.13` in `go.mod`
- refresh `go.sum` to the v0.13.13 checksums
- update generated `assets/jsconfig.json` path metadata to the resolved v0.13.13 module cache path

## Test plan
- [x] run `hugo --quiet`
- [ ] run `hugo mod graph` and confirm module resolution includes v0.13.13

Made with [Cursor](https://cursor.com)