### PR TITLE
Rebrand agent observability workshop

### DIFF
--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
@@ -5,7 +5,7 @@ weight: 1
 time: 5 minutes
 ---
 
-In [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
+In [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
 (coordinator, flight specialist, hotel specialist, activity specialist, and synthesizer) calls an LLM
 through **LangChain**'s `ChatOpenAI`.
 

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
@@ -5,20 +5,20 @@ weight: 1
 time: 5 minutes
 ---
 
-In [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
+In [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) you instrumented and observed an **agentic AI travel planner**. That application is a **Flask API** wrapping a **LangGraph** workflow, where each node
 (coordinator, flight specialist, hotel specialist, activity specialist, and synthesizer) calls an LLM
 through **LangChain**'s `ChatOpenAI`.
 
-In this follow-on workshop, you will take that same application and add **Galileo instrumentation** to
-it. Rather than re-instrumenting from scratch, you'll attach a single Galileo callback to the LangGraph
+In this follow-on workshop, you will take that same application and add **Splunk Agent Observability instrumentation** to
+it. Rather than re-instrumenting from scratch, you'll attach a single Splunk Agent Observability callback to the LangGraph
 workflow so every agent's LLM call is captured. This lets you compare and validate AI trace visibility
 across tools using a workload you already understand.
 
 {{% prerequisites title="Prerequisites" %}}
 
 * The workshop 18 travel planner app (`~/workshop/agentic-ai/base-app`), or your own copy of it.
-* A Galileo account and API key.
-* An OpenAI API key (an `OPENAI_API_KEY` will be pre-defined on your workshop instance).
+* A Splunk Agent Observability account and API key.
+* An OpenAI API key (the same `OPENAI_API_KEY` the app already uses).
 * Python 3.10+ environment with package install access.
 
 {{% /prerequisites %}}

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/2-quickstart-setup.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/2-quickstart-setup.md
@@ -5,17 +5,16 @@ weight: 2
 time: 5 minutes
 ---
 
-Start by adding the Galileo SDK to the travel planner's environment and initializing Galileo tracing.
+Start by adding the Galileo SDK to the travel planner's environment and initializing Splunk Agent Observability tracing.
 
 {{< exercise title="Quickstart setup" >}}
 
 {{< step title="Activate Environment"  >}}
 
-Navigate to the app directory and create a new virtual environment:
+Navigate to the app directory and activate the virtual environment you created in [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) (or create a fresh one):
 
 ```bash
 cd ~/workshop/agentic-ai/base-app
-python3 -m venv .venv
 source .venv/bin/activate
 ```
 
@@ -23,54 +22,44 @@ source .venv/bin/activate
 
 {{< step title="Install Galileo SDK"  >}}
 
+Install the Galileo SDK alongside the app's existing dependencies:
+
+```bash
+pip install galileo python-dotenv
+```
+
 The app already installs `langchain`, `langchain-openai`, `langgraph`, and `flask` via its
-`requirements.txt`. Galileo's LangChain callback ships with the `galileo` package, so 
-let's add it here. 
-
-Open the `~/workshop/agentic-ai/base-app/requirements.txt` file for editing 
-and add the following packages: 
-
-```bash
-galileo
-python-dotenv
-```
-
-Then add all of the packages to the virtual environment: 
-
-```bash
-pip install -r requirements.txt
-```
+`requirements.txt`. The Galileo LangChain callback ships with the `galileo` package.
 
 {{< /step >}}
 
 {{< step title="Configure Galileo credentials"  >}}
 
-Your EC2 instance comes pre-configured with `OPENAI_API_KEY` and 
-`OPENAI_BASE_URL` environment variables, which will be used by the application. 
-
-To define additional environment variables, create a new file named
-`~/workshop/agentic-ai/base-app/.env` and add your credentials: 
+Add your credentials to the app's `.env` file.
 
 ```ini
+OPENAI_API_KEY="your-openai-api-key"
+OPENAI_BASE_URL="https://lite-llm-proxy.splunko11y.com/v1"
 GALILEO_API_KEY="your-galileo-api-key"
 GALILEO_CONSOLE_URL="https://console.multitenant.galileocloud.io"
-# If you comment out the next two uncommented lines, Galileo uses a project and log
+# Recommended: uncomment to group this workshop's traces under their own project
+# and log stream. If you leave these commented out, Splunk Agent Observability uses a project and log
 # stream both named "default".
-GALILEO_PROJECT="Workshop19Galileo"
-GALILEO_LOG_STREAM="TravelPlanner-${INSTANCE}"
+# GALILEO_PROJECT="Workshop19"
+# GALILEO_LOG_STREAM="TravelPlanner"
 ```
 
-{{< /step >}}
+Uncommenting `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` keeps the workshop traces easy to find.
+Leaving them commented is fine too — your traces will just land in the `default` project and
+`default` log stream.
 
-{{< step title="Initialize Galileo in the app"  >}}
-Initialize Galileo near the top of `~/workshop/agentic-ai/base-app/main.py`, right before `import logging`. Passing the environment variables through means the project and log stream come from your `.env` when set, and fall back to Galileo's `default`/`default` when not:
+4. Initialize Splunk Agent Observability near the top of `main.py`, right after the existing imports and
+   `load_dotenv()` call. Passing the environment variables through means the project and log
+   stream come from your `.env` when set, and fall back to Splunk Agent Observability's `default`/`default` when not:
 
 ```python
 import os
-from dotenv import load_dotenv
 from galileo import galileo_context
-
-load_dotenv()
 
 galileo_context.init(project=os.getenv("GALILEO_PROJECT"),
                      log_stream=os.getenv("GALILEO_LOG_STREAM"))
@@ -82,12 +71,12 @@ galileo_context.init(project=os.getenv("GALILEO_PROJECT"),
 
 {{< checkpoint title="Knowledge Check" >}}
 
-If you comment out the `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` variables in your `.env`, where will
-your traces show up in Galileo?
+If you leave `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` commented out in your `.env`, where will
+your traces show up in Splunk Agent Observability?
 
 {{< details summary="Click here to see the answer" >}}
 They'll land in a project named `default` and a log stream named `default`. Because `main.py`
 passes `os.getenv("GALILEO_PROJECT")` and `os.getenv("GALILEO_LOG_STREAM")`, those values are
-`None` when the variables are unset, and the Galileo SDK falls back to its built-in `default`
+None` when the variables are unset, and the Galileo SDK falls back to its built-in `default`
 project and `default` log stream.
 {{< /details >}}

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/3-add-langchain-callback.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/3-add-langchain-callback.md
@@ -9,8 +9,8 @@ Galileo's `GalileoCallback` is a standard LangChain callback handler. When you a
 LangChain or LangGraph run, it automatically captures prompts, responses, model names, token usage,
 timing, and the nesting of each step.
 
-Because the travel planner is a **LangGraph** workflow, you don't need to edit every node. Instead,
-pass a single callback in the **run config** when the compiled graph is streamed. Galileo then records
+Because the travel planner is a LangGraph workflow, you don't need to edit every node. Instead,
+pass a single callback in the run config when the compiled graph is streamed. Splunk Agent Observability then records
 one trace per request, with a nested LLM span for each agent node (coordinator, flight, hotel,
 activity, and synthesizer).
 
@@ -30,15 +30,21 @@ from galileo.handlers.langchain import GalileoCallback
 In `plan_travel_internal()`, create a callback and attach it to the run config passed to `compiled_app.stream(...)`. The existing code should look something like this:
 
 ```python
+    workflow = build_workflow()
+    compiled_app = workflow.compile()
+
     for step in compiled_app.stream(initial_state, config):
         node_name, node_state = next(iter(step.items()))
         final_state = node_state
-        agent_steps.append({"agent": node_name, "status": "completed"})
 ```
 
-Update it to build a config that includes the Galileo callback (merging it with any existing config the app already passes). This passes the execution of each node in the agent to Galileo:
+   Update it to build a config that includes the Splunk Agent Observability callback (merging it with any existing
+   config the app already passes). This passes the execution of each node in the agent to Splunk Agent Observability:
 
 ```python
+    workflow = build_workflow()
+    compiled_app = workflow.compile()
+
     # One callback per request keeps each travel plan in its own trace.
     callback = GalileoCallback()
     run_config = {**config, "callbacks": [callback]}
@@ -46,7 +52,6 @@ Update it to build a config that includes the Galileo callback (merging it with 
     for step in compiled_app.stream(initial_state, run_config):
         node_name, node_state = next(iter(step.items()))
         final_state = node_state
-        agent_steps.append({"agent": node_name, "status": "completed"})
 ```
 
 Passing the callback at the graph level means it propagates to every node's `llm.invoke(...)` call automatically. No further instrumentation is needed.
@@ -57,12 +62,10 @@ Passing the callback at the graph level means it propagates to every node's `llm
 
 {{< checkpoint title="Knowledge Check" >}}
 
-Is the Galileo callback used by the example application synchronous or asynchronous? 
+Where do you attach the `GalileoCallback` in a LangGraph workflow?
 
-{{< details summary="Click here to see the answer" >}}
-The example application uses a synchronous callback. 
-
+{{% notice title="Async workflows" style="blue" icon="info-circle" %}}
 If your app streams the graph asynchronously (`compiled_app.astream(...)`), use
 `GalileoAsyncCallback` instead of `GalileoCallback`. The travel planner runs synchronously, so
 `GalileoCallback` is correct here.
-{{< /details >}}
+{{% /notice %}}

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/4-run-and-verify-trace.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/4-run-and-verify-trace.md
@@ -5,9 +5,20 @@ weight: 4
 time: 5 minutes
 ---
 
-Run the travel planner, send a request through it, then confirm the multi-agent trace landed in Galileo.
+Run the travel planner, send a request through it, then confirm the multi-agent trace landed in
+Splunk Agent Observability.
 
 {{< exercise title="Run the app and verify the trace" >}}
+
+{{< step title="Active Environment" >}}
+Navigate to the base-app directory and activate the virtual environment:
+
+```bash
+cd ~/workshop/agentic-ai/base-app
+source .venv/bin/activate
+```
+
+{{< /step >}}
 
 {{< step title="Run the app"  >}}
 Start the app:
@@ -32,7 +43,8 @@ INFO:root:[INFO] Starting Flask server on http://0.0.0.0:8080
 {{% /tab %}}
 {{< /tabs >}}
 
-{{< /step >}}
+3. In a second terminal, which is signed in to the same environment, send a travel-planning request. You should get the planned itinerary back,
+   confirming the workflow still runs end-to-end with the callback attached:
 
 {{< step title="Send a request to the app"  >}}
 In a second terminal, send a travel-planning request. You should get the planned itinerary back, confirming the workflow still runs end-to-end with the callback attached:
@@ -94,24 +106,9 @@ curl http://localhost:8080/travel/plan \
 {{% /tab %}}
 {{< /tabs >}}
 
-{{< /step >}}
-
-{{< step title="Verify the trace in Galileo" >}}
-
-In the Galileo console (https://console.multitenant.galileocloud.io/splunkse), 
-open the `Workshop19Galileo` project (unless you commented out the `GALILEO_PROJECT` environment
-variable in the `.env` file). 
-
-Then, to find your log stream, first echo the `INSTANCE` environment variable on 
-your EC2 instance: 
-
-```bash
-echo $INSTANCE
-```
-
-Then look for the log stream named `TravelPlanner-` followed by your instance name. 
-For example, `TravelPlanner-shw-9306`. 
-
+4. In the Splunk Agent Observability console (https://console.multitenant.galileocloud.io/splunkse) , open the project and log stream your traces landed in. If you uncommented
+   `GALILEO_PROJECT` and `GALILEO_LOG_STREAM` in your `.env`, that's `Workshop19` /
+   `TravelPlanner`; otherwise it's the `default` project and `default` log stream.
 {{< /step >}}
 
 {{< step title="Find the trace" >}}
@@ -131,12 +128,13 @@ Expand any span and verify it captured the **system and human messages**, the **
 
 {{% notice title="No trace showing up?" style="tip" icon="exclamation-triangle" %}}
 
+* Confirm you were able to log-in to the same environment before sending the request payload, by using a separate terminal session.
 * Confirm `GALILEO_API_KEY` is set in the environment the app runs in (it loads `.env` via
   `load_dotenv()`).
 * Confirm you're viewing the right project and log stream: the values from `GALILEO_PROJECT` /
   `GALILEO_LOG_STREAM` if you set them, or `default` / `default` if you didn't.
 * If you don't see the project, you likely don't have the correct permissions.
-* Check the app logs for Galileo errors in the bash where `python3 main.py` is running.
+* Check the app logs for Splunk Agent Observability errors in the bash where `python3 main.py` is running.
 * Confirm that you are in the `splunkse` organization in the top left of the web page.
 
 {{% /notice %}}
@@ -150,7 +148,7 @@ A single travel-planning request produces one trace containing five nested LLM s
 than five separate traces. Why?
 
 {{< details summary="Click here to see the answer" >}}
-Because the whole LangGraph workflow runs as **one root run** per request, and the callback was
+Because the whole LangGraph workflow runs as one root run per request, and the callback was
 attached to that run's config. LangGraph executes the five nodes (coordinator, flight, hotel,
 activity, synthesizer) within that single run, so each node's `llm.invoke(...)` becomes a child
 span under the same trace. If you instead created a new callback and a new run for each node, you'd

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/5-wrap-up.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/5-wrap-up.md
@@ -5,23 +5,24 @@ weight: 5
 time: 20 minutes
 ---
 
-You took the [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) multi-agent travel planner and instrumented it with Galileo (Splunk Agent Observability) by adding just two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
+You took the workshop 18 multi-agent travel planner and instrumented it with Splunk Agent Observability by adding just
+two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
+With that, every agent node's LLM call now appears as a nested span in a single Splunk Agent Observability trace per
+request — no per-node changes required and very low maintenance.
 
-With that, every agent node's LLM call now appears as a nested span in a single Galileo trace per request — no per-node changes required and very low maintenance.
-
-You now have the same workload traced in **two** observability tools (Splunk Observability Cloud from [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/), and Galileo here), which is a useful basis for comparison.
+You now have the same workload traced in two observability tools (Splunk Observability Cloud from
+workshop 18, and Splunk Agent Observability here), which is a useful basis for comparison. What does Agent Observability show you that Observability Cloud doesn't, and vice versa?
 
 Next, we're going to expand on this by:
 
-* Adding Galileo metrics (for example, `Context Adherence`) to the captured traces.
-* Working through the features that help Galileo support better observability of agents.
-* Leveraging powerful features like Signals.
-* Using a dedicated `GalileoLogger(project=..., log_stream=...)` to route specific runs to different log streams.
+* Adding Splunk Agent Observability metrics (for example, `Context Adherence`) to the captured traces.
+* Working through the features that help Splunk Agent Observability support better observability of agents.
+* Leveraging powerful features like Signals in AI Assistant.
+* Using a dedicated `GalileoLogger(project=..., log_stream=...)` to route specific runs to different
+  log streams.
 * Adding more complexity to our agents.
 
 ## References
 
-* [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
-* [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)
-
-{{< checkpoint title="Workshop complete -- **nice work!**" >}}
+* [Splunk Agent Observability Quickstart](https://docs.galileo.ai/getting-started/quickstart)
+* [Splunk Agent Observability LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/_index.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Galileo Instrumentation for LangChain Apps
-linkTitle: Galileo Instrumentation for LangChain Apps
+title: Splunk Agent Observability Instrumentation for LangChain Apps
+linkTitle: Splunk Agent Observability Instrumentation for LangChain Apps
 weight: 19
 layout: chapter
 time: 40 minutes
 authors: ["Sam Goldfield"]
-description: Add Galileo (Splunk Agent Observability) tracing to a LangChain app and inspect traces in the console UI.
+description: Add Splunk Agent Observability tracing to a LangChain app and inspect traces in the console UI.
 draft: false
 hidden: false
 aliases:
@@ -13,24 +13,22 @@ aliases:
 product: "Observability Cloud"
 ---
 
-This workshop picks up after workshop 1 and shows the fastest path to instrumenting a LangChain app with Galileo.
+This workshop picks up after workshop 18 and shows the fastest path to instrumenting a LangChain app with Splunk Agent Observability, powered by Galileo.
 
-You will reuse the **multi-agent travel planner** from workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/). It is a Flask API backed by a LangGraph
+You will reuse the **multi-agent travel planner** from workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/). It is a Flask API backed by a LangGraph
 workflow whose nodes (coordinator, flight specialist, hotel specialist, activity specialist, and
 synthesizer) each call an LLM through LangChain. Instead of sending its telemetry to Splunk
-Observability Cloud, you'll trace it with Galileo (Splunk Agent Observability).
+Observability Cloud, you'll trace it with Splunk Agent Observability.
 
 {{< objectives title="Objectives" >}}
 
-* Install the Galileo SDK and set required environment variables.
-* Add Galileo context initialization and a single LangChain callback to the travel planner.
-* Run a real travel-planning request and verify the full multi-agent trace in the Galileo console.
+* Install the Splunk Agent Observability SDK and set required environment variables.
+* Add Splunk Agent Observability context initialization and a single LangChain callback to the travel planner.
+* Run a real travel-planning request and verify the full multi-agent trace in the Splunk Agent Observability console.
 
 {{< /objectives >}}
 
 {{% notice style="info" title="Primary references" %}}
 
-* [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
-* [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)
-
-{{% /notice %}}
+* [Splunk Agent Observability Quickstart](https://docs.galileo.ai/getting-started/quickstart)
+* [Splunk Agent Observability LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)


### PR DESCRIPTION
Updates only content/en/ninja-workshops/ai/2-agent-observability-galileo to use Splunk Agent Observability for user-facing references while preserving required SDK identifiers and URLs.

Co-Authored-By: Oz <oz-agent@warp.dev>