### PR TITLE
Fix root alias redirect string quoting

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -9,8 +9,8 @@
   <script>
     (function () {
       // Auto-forward root alias pages (for example /observability-workshop/) to /<lang>/.
-      var target = {{ .Permalink | jsonify }};
-      var langSegment = {{ printf "%s/" (site.Language.Lang | default "en") | jsonify }};
+      var target = "{{ .Permalink }}";
+      var langSegment = "{{ site.Language.Lang | default "en" }}/";
       var normalize = function (path) {
         if (!path) return "/";
         return path.replace(/\/+$/, "") + "/";


### PR DESCRIPTION
## Summary
- fix alias redirect script variable rendering in `layouts/alias.html`
- remove extra JSON-style quoting from `target` and `langSegment` values
- restore automatic root redirect from `/observability-workshop/` to `/observability-workshop/en/`

## Test plan
- [x] run `hugo --quiet`
- [ ] open `https://splunk.github.io/observability-workshop/` and verify it auto-redirects to `/observability-workshop/en/`

Made with [Cursor](https://cursor.com)