### PR TITLE
Update workshop links in agent observability docs

### DIFF
--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/1-introduction.md
@@ -16,7 +16,7 @@ across tools using a workload you already understand.
 
 {{% prerequisites title="Prerequisites" %}}
 
-* The workshop 18 travel planner app (`~/workshop/agentic-ai/base-app`), or your own copy of it.
+* The workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) travel planner app (`~/workshop/agentic-ai/base-app`), or your own copy of it.
 * A Splunk Agent Observability account and API key.
 * An OpenAI API key (the same `OPENAI_API_KEY` the app already uses).
 * Python 3.10+ environment with package install access.

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/2-quickstart-setup.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/2-quickstart-setup.md
@@ -11,7 +11,7 @@ Start by adding the Galileo SDK to the travel planner's environment and initiali
 
 {{< step title="Activate Environment"  >}}
 
-Navigate to the app directory and activate the virtual environment you created in [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/) (or create a fresh one):
+Navigate to the app directory and activate the virtual environment you created in [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) (or create a fresh one):
 
 ```bash
 cd ~/workshop/agentic-ai/base-app

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/5-wrap-up.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/5-wrap-up.md
@@ -5,13 +5,13 @@ weight: 5
 time: 20 minutes
 ---
 
-You took the workshop 18 multi-agent travel planner and instrumented it with Splunk Agent Observability by adding just
+You took the workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) multi-agent travel planner and instrumented it with Splunk Agent Observability by adding just
 two things: `galileo_context.init(...)` and a single `GalileoCallback` on the LangGraph run config.
 With that, every agent node's LLM call now appears as a nested span in a single Splunk Agent Observability trace per
 request — no per-node changes required and very low maintenance.
 
 You now have the same workload traced in two observability tools (Splunk Observability Cloud from
-workshop 18, and Splunk Agent Observability here), which is a useful basis for comparison. What does Agent Observability show you that Observability Cloud doesn't, and vice versa?
+[Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/), and Splunk Agent Observability here), which is a useful basis for comparison. What does Agent Observability show you that Observability Cloud doesn't, and vice versa?
 
 Next, we're going to expand on this by:
 

--- a/content/en/ninja-workshops/ai/2-agent-observability-galileo/_index.md
+++ b/content/en/ninja-workshops/ai/2-agent-observability-galileo/_index.md
@@ -11,9 +11,9 @@ aliases:
 product: "Observability Cloud"
 ---
 
-This workshop picks up after workshop 18 and shows the fastest path to instrumenting a LangChain app with Splunk Agent Observability, powered by Galileo.
+This workshop picks up after workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/) and shows the fastest path to instrumenting a LangChain app with Splunk Agent Observability, powered by Galileo.
 
-You will reuse the **multi-agent travel planner** from workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/18-agentic-ai/). It is a Flask API backed by a LangGraph
+You will reuse the **multi-agent travel planner** from workshop [Monitoring Agentic AI Applications](ninja-workshops/ai/1-agentic-ai/). It is a Flask API backed by a LangGraph
 workflow whose nodes (coordinator, flight specialist, hotel specialist, activity specialist, and
 synthesizer) each call an LLM through LangChain. Instead of sending its telemetry to Splunk
 Observability Cloud, you'll trace it with Splunk Agent Observability.


### PR DESCRIPTION
## Summary
- update the agent observability workshop docs to point at the correct workshop links
- keep the link fixes scoped to the introduction, quickstart, wrap-up, and section index pages

## Testing
- not run (documentation-only changes)

## Notes
- conversation: https://app.warp.dev/conversation/b870d81b-db11-4e17-bccb-cb4662e3d270

Co-Authored-By: Oz <oz-agent@warp.dev>
