### PR TITLE
new ingress.yaml for Astronomy Shop

### DIFF
--- a/workshop/apm/splunk-astronomy-shop/ingress.yaml
+++ b/workshop/apm/splunk-astronomy-shop/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+spec:
+  ingressClassName: traefik
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-proxy
+            port:
+              number: 8080
+


### PR DESCRIPTION
## Summary

ingress needed for Show instance

## Type of change

- [x] Other — describe: separate .yaml for ingress until it is included by default in the new astronomy shop deployment

## What's affected

- Show instance for new Astronomy Shop workshop

## Reviewer focus

Anything you'd specifically like the reviewer to check? (e.g. "verify the `kubectl` command in step 3 against the current OTel collector"). Leave blank if not applicable.

## Screenshots / preview

For visual changes, paste a before/after screenshot or a Hugo preview link.

## Verification

- [x] `hugo` builds cleanly (no warnings or errors)
- [n/a] `npx markdownlint-cli2 '<paths/*.md>'` passes for touched files
- [n/a] Any new images have meaningful alt text
- [x] No TODO image placeholders left unintentionally
- [x] No published URLs changed, OR `aliases:` frontmatter added for any renamed / moved pages
- [x] Identified and updated parallel / sibling pages where this workshop shares content with another (e.g. `observability-cloud-short` ↔ `observability-cloud`), OR confirmed none exist
