### PR TITLE
Set diab defaultVariant to max

### DIFF
--- a/workshop/bots-o11y/splunk-astronomy-shop-2.0.5-diab.yaml
+++ b/workshop/bots-o11y/splunk-astronomy-shop-2.0.5-diab.yaml
@@ -1363,7 +1363,7 @@ data:
             "targeted": "targeted",
             "max": "max"
           },
-          "defaultVariant": "minimal"
+          "defaultVariant": "max"
         }
       }
     }


### PR DESCRIPTION
## Change
Set `defaultVariant` from `minimal` to `max` in `workshop/bots-o11y/splunk-astronomy-shop-2.0.5-diab.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)