### PR TITLE
Add tokenomics fundamentals workshop

### DIFF
--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/1-welcome-aboard/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/1-welcome-aboard/_index.md
@@ -1,0 +1,32 @@
+---
+title: From token counts to token value
+linkTitle: 1. From token counts to token value
+weight: 1
+time: 5 minutes
+---
+
+For the next 90 minutes, we're going to cover how agentic applications consume tokens and how
+we can validate that those tokens are effectively used.
+
+Our goal is not simply to minimize tokens. The cheapest agent that produces the wrong answer
+is not efficient. Neither is a highly accurate agent whose unnecessary loops, oversized
+context, and expensive model choices make it impossible to scale.
+
+> The question we will keep asking is: **what outcome did we receive for the tokens we spent?**
+
+We will use a number of tools, including the health agent assistant. It looks up patient records
+using an LLM, retrieval, and tools. Bills by themselves do not explain:
+
+* Which users, agents, models, and workflow steps consume the tokens?
+* Whether expensive requests are better than inexpensive requests?
+* Whether a prompt, model, retrieval, or tool change would improve the ratio?
+
+{{< checkpoint title="Knowledge Check" >}}
+
+If your bill doubled for AI this month, what would you check to make sure it was justified?
+
+{{< details summary="Click here to see the answer" >}}
+You could check which agents, models, and workflows consumed the tokens, what value
+proposition those use cases support, and whether that has led to an improvement in outcome. How do you
+qualify those improvements? Read on!
+{{< /details >}}

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/2-why-agents-become-inefficient/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/2-why-agents-become-inefficient/_index.md
@@ -1,0 +1,41 @@
+---
+title: Why Agents Become Token-Inefficient
+linkTitle: 2. Three Causes
+weight: 2
+time: 10 minutes
+---
+
+### Cause 1: the wrong model
+
+A capable, expensive model may be used for every step, including routing, extraction, or
+classification that a smaller model could handle. The inverse also creates waste: a model that
+is too weak may retry, call unnecessary tools, or require larger prompts to complete the task.
+
+The optimization question is not "Which model is cheapest?" It is which model delivers the required quality and latency for this specific step at the lowest sustainable cost?
+
+### Cause 2: over-engineered or verbose tools and workflows
+
+Token waste can hide in:
+
+* Tool descriptions repeated with every model call.
+* Retrieval that returns too many, too few, or incorrectly sized chunks.
+* Full conversation history sent when only recent context matters.
+* Planner and tool loops that do not converge.
+* Retries that repeat the same failing action.
+* Verbose tool responses passed back into the model unchanged.
+
+Design of your agent is very important.
+
+### Cause 3: spend without outcomes
+
+Bills will tell you how much the tokens cost, but not:
+
+* Which agentic use case consumed it?
+* Which value proposition it was supporting?
+* Did the response meet the required quality and safety bar?
+* Did an inexpensive configuration outperform an expensive one?
+
+Without that context, teams optimize totals instead of value.
+
+We're going to review how Splunk Agent Observability handles visibility and evaluation of these common failure modes,
+and how the platform can help you make effective decisions and take action quickly to better use your tokens.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/3-make-the-black-box-visible/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/3-make-the-black-box-visible/_index.md
@@ -1,0 +1,25 @@
+---
+title: Gaining Visibility
+linkTitle: 3. Gain Visibility
+weight: 3
+time: 10 minutes
+---
+## Architecture
+
+Our assistant uses Streamlit, LangGraph, an OpenAI model, PostgreSQL with pgvector, and three tools.
+One medication question can invoke an LLM, retrieval, a tool, and another LLM call. It is instrumented
+into Splunk Agent Observability with a callback.
+
+Requests into our assistant show up as sessions, traces, and spans.
+
+* A **session** is a multi-turn conversation
+* A **trace** is one end-to-end agent request, starting from an input and ending with its output. One turn of the conversation.
+* A **span** is one step of the trace such as an LLM call, retrieval, or tool call.
+
+Open the prepared Lisinopril trace:
+
+1. Start with total input tokens, output tokens, latency, and cost.
+2. Expand the span tree to show the path the agent chose.
+3. Select an LLM span and point out model, prompt, response, and token counts.
+4. Select the retrieval or tool span and show how its output becomes context for the next call.
+5. Return to the root span and connect the detailed steps to the total.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/4-cause-one-wrong-model/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/4-cause-one-wrong-model/_index.md
@@ -1,0 +1,89 @@
+---
+title: Cause 1 — The Wrong Model
+linkTitle: 4. Choose the Right Model
+weight: 4
+time: 15 minutes
+---
+
+A fair bake-off controls the workload. If we change the model, prompt, dataset, and retrieval
+settings at once, we cannot explain the result. In this comparison, both experiments receive the
+same 18 product questions, retrieved context, and evaluators. The model is the variable.
+
+Open **Experiment Groups > Product Model Comparison**, select the two experiments, and switch to
+**Compare**.
+
+### 1. Compare the response generations
+
+Open the input asking whether the Femella Women Gold Shirt is eligible for exchange. Both models
+receive product context that explicitly says `Exchangeable: yes`.
+
+The inexpensive model answers:
+
+> Yes, we offer exchanges on many of our items.
+
+The expensive model answers the specific question directly, confirms that this shirt is eligible,
+and adds the available return, try-and-buy, and store-pickup options.
+
+What do you notice about the two answers? The first is concise but does not confirm the requested
+product. The second is more useful, but it is also longer.
+
+### 2. Compare quality
+
+Expand **Trace Evaluators** for the two results:
+
+| Evaluator | Inexpensive model | Expensive model |
+|-----------|-------------------|-----------------|
+| Context Adherence | 1.00 | 1.00 |
+| Ground Truth Adherence | false | true |
+
+Both responses are consistent with the retrieved context, but only one satisfies the expected
+answer. Context adherence alone does not prove that the user's task was completed.
+
+### 3. Compare tokens, latency, and cost
+
+| System metric | Inexpensive model | Expensive model |
+|---------------|-------------------|-----------------|
+| Input tokens | 279 | 298 |
+| Output tokens | 12 | 59 |
+| Total tokens | 291 | 357 |
+| Latency | 292 ms | 2.36 sec |
+| Agent cost | less than $0.0001 | $0.0026 |
+
+These values describe this single prepared comparison; they are not universal model benchmarks.
+The inexpensive model is faster and cheaper here, but it fails Ground Truth Adherence. The
+expensive model completes the task, but costs more and produces a longer answer.
+
+> Token efficiency is not always proportional to price or token count. A response that uses fewer
+> tokens but does not complete the task may create another user turn, an escalation, or an
+> abandoned journey.
+
+### 4. Decide how to route
+
+Which choice would you make?
+
+1. Send every request to the inexpensive model.
+2. Send every request to the expensive model.
+3. Route by task complexity and required quality.
+
+A configuration should advance only when it:
+
+1. Meets the defined quality and safety thresholds.
+2. Improves cost, latency, or both for the target task.
+3. Remains consistent across the dataset, not just one favorable example.
+
+{{< checkpoint title="Knowledge Check" >}}
+
+Why is the inexpensive response not the token-efficient winner, despite using fewer tokens and
+costing less?
+
+{{< details summary="Click here to see the answer" >}}
+It does not complete the user's task. Ground Truth Adherence is false because the response talks
+about exchanges generally without confirming whether the specific shirt is eligible. Efficiency
+must include the outcome, not just consumption.
+{{< /details >}}
+
+Do not conclude that larger models are always better. The right model is workload-specific and
+should be selected with controlled, repeatable evidence.
+
+Next, suppose we selected the right model and the request is still expensive. The next suspect is
+the workflow wrapped around it.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/5-cause-two-workflow-waste/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/5-cause-two-workflow-waste/_index.md
@@ -1,0 +1,80 @@
+---
+title: Cause 2 — Over-Engineered Workflows
+linkTitle: 5. Simplify the Workflow
+weight: 5
+time: 15 minutes
+---
+
+A correctly selected model can still be wrapped in an inefficient workflow. Open the prepared
+**E-Commerce Customer Session** to see the work behind several customer-facing answers.
+
+The message view shows product discovery, shopping advice, exchanges, loyalty points, and returns
+within one session. The span tree shows how the agent handles those turns.
+
+### 1. Follow one request through the workflow
+
+Expand a **Customer Q&A Question** trace and identify the main stages:
+
+1. **Classify Turn** determines the user's intent.
+2. **Model Router** selects a model for the task.
+3. **Knowledge Base Retrieval** finds relevant product or policy context.
+4. The selected model generates the final answer.
+
+A user sees one response, but the system may perform several model and retrieval operations. Each
+step has to justify the tokens and latency it adds.
+
+### 2. Inspect the trace shape
+
+Compare several turns in the same session. The prepared view shows individual turns taking roughly
+2.49 to 4.9 seconds. Expand the slower turns and ask:
+
+* Did the workflow add a model or retrieval call?
+* Did a step repeat or retry?
+* Did the selected route match the user's intent?
+* Did retrieval return more context than the answer required?
+
+Extra spans are not automatically waste. A retrieval step may be essential for a grounded answer.
+The goal is to find work that does not improve the outcome.
+
+### 3. Locate token growth
+
+Select each LLM span and compare its input and output tokens. Then inspect the span immediately
+before it. Common sources of growth include:
+
+* Too many retrieved chunks or chunks that are incorrectly sized.
+* Full conversation history sent when only recent context matters.
+* Verbose tool definitions or results repeated on every call.
+* A router sending a simple request through an unnecessarily complex path.
+* Retries that repeat the same action without changing the inputs.
+
+### 4. Check the session evaluators
+
+Return to the session and review **Action Completion** and **Agent Efficiency**. In the prepared
+example, Action Completion is `true` while Agent Efficiency is `false`.
+
+This distinction matters: an agent can eventually complete the user's task while taking an
+inefficient route. Open the Agent Efficiency result to read its rationale and identify the turn or
+behavior that should be investigated.
+
+> Successful is not the same as efficient. Agent-level evaluation helps find waste that a simple
+> error-rate chart will miss.
+
+Which change would you test first, and what regression could it introduce?
+
+* Fewer retrieval chunks may omit necessary evidence.
+* Shorter history may lose conversational intent.
+* A simpler route may send a difficult request to an unsuitable model.
+* Tighter retry limits may reduce recovery from transient failures.
+
+{{< checkpoint title="Knowledge Check" >}}
+
+Why can Action Completion be true while Agent Efficiency is false?
+
+{{< details summary="Click here to see the answer" >}}
+The agent can reach the requested outcome while using unnecessary steps, context, retries, or an
+expensive route. Action Completion measures whether the work was completed; Agent Efficiency asks
+whether the path taken was effective and economical.
+{{< /details >}}
+
+We have now attributed spend to a model and to a workflow. Next, we will connect those individual
+requests to trends and outcomes across the application.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/6-cause-three-spend-without-outcomes/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/6-cause-three-spend-without-outcomes/_index.md
@@ -1,0 +1,87 @@
+---
+title: Cause 3 — Spend Without Outcomes
+linkTitle: 6. Connect Spend to Outcomes
+weight: 6
+time: 15 minutes
+---
+
+Individual traces explain one interaction. Trends show whether the same behavior is isolated or
+repeated across production traffic.
+
+Open the `workshop` agent stream and select **Trends**.
+
+### 1. Compare consumption with demand
+
+Under **System Metrics**, review:
+
+* Total Tokens
+* Input Tokens and Output Tokens
+* Agent Cost
+* Latency
+* Traces Count
+* API Failures
+
+The prepared environment contains 290 traces and large synthetic token and cost spikes. Treat
+these values as workshop data, not as typical production volumes or costs.
+
+Start with the relationship between metrics rather than the total alone:
+
+* Did tokens rise because trace volume rose?
+* Did cost increase faster than traffic?
+* Was the spike driven by input tokens, output tokens, or both?
+* Did latency or failures change at the same time?
+
+A bill can show the cost spike. These trends show whether it came from healthy demand or a change
+in cost per interaction.
+
+### 2. Segment the trend
+
+Use **Group by** and **Filters** to narrow the time window and isolate the dimensions present in
+the telemetry, such as model, project, agent stream, environment, or application attributes.
+
+The objective is to move from:
+
+> Token usage increased.
+
+To a statement that can be acted on:
+
+> Input tokens increased for one route after a version change, while trace volume remained stable.
+
+### 3. Add custom and agent-quality metrics
+
+Scroll to **Custom Metrics** and **Agent Quality**. The prepared stream includes:
+
+* `model_selection_match`, showing whether the selected model matched the expected route.
+* **Agent Efficiency**, showing whether the agent took an effective path.
+* **Action Completion**, showing whether the user's requested action was completed.
+
+These metrics connect consumption to behavior and outcome. For example, a token spike accompanied
+by lower `model_selection_match` suggests a routing problem. Stable Action Completion with falling
+Agent Efficiency suggests that tasks still finish, but with more work than necessary.
+
+### 4. Drill into evidence
+
+Select a period with a cost or token spike, filter the trace list to that interval, and open a
+representative trace. The trend identifies the population; the trace explains the cause.
+
+Consider four combinations:
+
+| Cost | Quality or outcome | Interpretation |
+|------|--------------------|----------------|
+| High | High | May be justified for difficult or high-risk work |
+| High | Low | Investigate first |
+| Low | High | Candidate to scale after validating consistency |
+| Low | Low | Fails cheaply; not an optimization success |
+
+{{< checkpoint title="Knowledge Check" >}}
+
+A token spike appears, but Traces Count is unchanged. What should you inspect next?
+
+{{< details summary="Click here to see the answer" >}}
+Compare input and output tokens, group by model or route, and inspect Agent Efficiency and
+`model_selection_match`. Then open traces from the spike to look for larger context, verbose
+outputs, retries, loops, or an unexpected model choice.
+{{< /details >}}
+
+Attribution tells us where to focus. The next step is to evaluate alternatives before release and
+continue checking their quality in production.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/7-bake-off-and-luna/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/7-bake-off-and-luna/_index.md
@@ -1,0 +1,83 @@
+---
+title: Bake Off and Optimize with Luna
+linkTitle: 7. Bake Off and Optimize
+weight: 7
+time: 15 minutes
+---
+
+Experiments let us compare candidate configurations before release. Evaluators let us continue
+measuring their behavior after release.
+
+### 1. Define the quality gate
+
+Return to **Product Model Comparison**. Before selecting a winner, decide which measures are
+required for the use case. In this example, Context Adherence and Ground Truth Adherence answer
+different questions:
+
+* **Context Adherence:** is the response supported by the supplied context?
+* **Ground Truth Adherence:** does the response match the expected answer?
+
+If thresholds are chosen after viewing the result, the team can fit the decision to the answer it
+already wanted. Define the acceptance bar first.
+
+### 2. Compare every input, not one example
+
+Use the arrows above the comparison to move through all 18 inputs. A model should not be selected
+from one favorable row or an average that hides important failures.
+
+For each configuration:
+
+1. Eliminate results that fail a required quality or safety threshold.
+2. Compare tokens, latency, and cost among the remaining candidates.
+3. Inspect failures by task type to decide whether routing is preferable to one global model.
+4. Record what must be monitored after release.
+
+### 3. Evaluate production sessions
+
+Return to the **E-Commerce Customer Session** and open the Evaluators panel. The session-level
+Agent Efficiency result includes a verdict, a rationale, the evaluator model, latency, and cost.
+This makes a score explainable: we can see why the evaluator marked the session inefficient and
+which behavior needs attention.
+
+Evaluation creates its own economic challenge. Using a large general-purpose model as a judge for
+every trace adds cost and latency, so teams often sample production traffic. Sampling can miss the
+rare routes and new behaviors that matter most.
+
+### 4. Optimize evaluation with Luna
+
+Luna is a family of purpose-built small language models for evaluation. Its role is to make broad,
+fast evaluation practical so quality can remain beside token, cost, and latency telemetry across
+the application lifecycle.
+
+The feedback cycle is:
+
+1. **Experiment:** compare models, prompts, and workflows on a fixed dataset.
+2. **Observe:** evaluate production traces and sessions.
+3. **Investigate:** open failed or expensive traces and read the evaluator rationale.
+4. **Improve:** change routing, prompts, tools, retrieval, or context.
+5. **Repeat:** rerun the experiment before release.
+
+> Luna does not directly reduce the application's generation tokens. It changes the economics of
+> the evaluation layer, helping teams find generation waste without replacing it with an equally
+> expensive evaluation problem.
+
+Current product material states that Luna SLMs can run evaluations and guardrails on 100% of
+traffic at **up to 98% lower cost than LLM-as-judge**. "Up to" is not an expected saving for every
+workload; actual results depend on the evaluator and traffic.
+
+{{< checkpoint title="Knowledge Check" >}}
+
+Why should experiment results and production evaluators be used together?
+
+{{< details summary="Click here to see the answer" >}}
+Experiments provide a controlled comparison before release. Production evaluators reveal quality,
+efficiency, and behavior as real traffic changes. Production findings then become new experiment
+cases, creating a continuous feedback cycle.
+{{< /details >}}
+
+What would you monitor after releasing the winning configuration? Consider quality drift, cost per
+completed action, token distribution, latency, route mix, retrieval size, loop frequency, and
+evaluator coverage.
+
+Optimization is a cycle, not a one-time model swap: instrument, attribute, evaluate, compare,
+release, and continuously validate.

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/8-bring-it-home/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/8-bring-it-home/_index.md
@@ -1,0 +1,52 @@
+---
+title: Bring It Home
+linkTitle: 8. Bring It Home
+weight: 8
+time: 5 minutes
+description: Close the tokenomics tour with a repeatable optimization cycle.
+---
+
+We began with a bill that told us how much was spent but not whether those tokens created value.
+We ended with a traceable decision: which configuration met the outcome bar, where its tokens went,
+and why it was the best trade-off for the workload.
+
+## The three causes
+
+1. **Wrong model:** choose models per task using quality, latency, and cost together.
+2. **Over-engineered workflow:** use spans and Agent Efficiency to find oversized context,
+   unnecessary calls, poor routes, loops, and retries.
+3. **Spend without outcomes:** place token and cost trends beside quality, Action Completion, and
+   business results.
+
+## The optimization cycle
+
+1. **Instrument** the complete agent workflow.
+2. **Locate** consumption at trace and span level.
+3. **Explain** the model or behavior that caused it.
+4. **Evaluate** whether it improved the outcome.
+5. **Compare** alternatives on a fixed dataset.
+6. **Release** only configurations that meet predefined thresholds.
+7. **Monitor and feed back** production evidence into the next experiment.
+
+{{< checkpoint title="Final Reflection" >}}
+
+Which of the three causes will you investigate first in your own agent workflow, and what evidence
+will you need before changing it?
+
+{{< details summary="Some questions to consider" >}}
+Do you need per-model token and cost trends, a trace showing context growth, an evaluator such as
+Agent Efficiency or Action Completion, a business outcome, or a controlled experiment comparing
+candidate configurations?
+{{< /details >}}
+
+> Do not optimize tokens in isolation. Optimize the useful, safe outcomes you receive from them.
+> Splunk Agent Observability gives you the evidence to make that trade-off visible and repeatable.
+
+## References
+
+* [Galileo documentation](https://docs.galileo.ai/)
+* [Galileo Quickstart](https://docs.galileo.ai/getting-started/quickstart)
+* [Galileo LangChain integration](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/langchain)
+* [Full Splunk Agent Observability workshop](../../4-splunk-agent-observability/)
+
+{{< checkpoint title="Tour complete" >}}

--- a/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/_index.md
+++ b/content/en/ninja-workshops/ai/6-splunk-agent-observability-tokenomics-introduction/_index.md
@@ -1,0 +1,52 @@
+---
+title: Tokenomics Fundamentals
+linkTitle: Tokenomics Fundamentals
+weight: 6
+layout: chapter
+time: 90 minutes
+authors: ["Sam Goldfield"]
+description: Connect token consumption to agent behavior, quality, and business outcomes, then find opportunities to improve efficiency with Splunk Agent Observability.
+draft: true
+hidden: true
+product: "Agent Observability"
+---
+
+Every prompt, tool call, context, and evaluation adds tokens, latency, and cost. A Gartner study concluded that "Agent models, for example, require between 5-30 times more tokens per task than a standard GenAI chatbot[...]". Token efficiency is becoming the pivotal question of AI adoption.
+
+This workshop in Splunk Agent Observability, powered by
+Galileo, connects token consumption to the traces, spans, quality signals, and business context
+that produced it.
+
+{{< objectives title="What you will learn" >}}
+
+* Understand how lightweight instrumentation exposes token usage, latency, cost, and agent
+  behavior in a single trace.
+* Attribute token consumption to specific models, tools, workflow steps, teams, and outcomes.
+* Compare configurations using consistent datasets and quality measures instead of cost alone.
+* Understand how Luna evaluation models make broad production evaluation economically practical.
+
+{{< /objectives >}}
+
+## Workshop Overview
+
+| Step | Topic | Time |
+|------|-------|------|
+| 1 | From token counts to token value | 5 minutes |
+| 2 | Three Causes | 10 minutes |
+| 3 | Gain Visibility | 10 minutes |
+| 4 | Choose the Right Model | 15 minutes |
+| 5 | Simplify the Workflow | 15 minutes |
+| 6 | Connect Spend to Outcomes | 15 minutes |
+| 7 | Bake Off and Optimize | 15 minutes |
+| 8 | Bring It Home | 5 minutes |
+
+The tour works with a live, pre-populated Splunk Agent Observability environment, prepared
+screenshots, or a combination of both. Product interaction is intentionally minimal: open a
+curated trace, inspect aggregate trends, and compare prepared experiment results.
+
+
+{{% notice title="Primary references" style="info" %}}
+
+* [Splunk Agent Observability documentation](https://agent-observability-docs.splunk.com/what-is-splunk-agent-observability)
+
+{{% /notice %}}


### PR DESCRIPTION
## Summary
- add a Tokenomics Fundamentals introduction workshop for Splunk Agent Observability
- cover model selection, workflow efficiency, outcome attribution, experiments, and Luna evaluation
- include eight guided sections with checkpoints and references

## Validation
- `hugo --source /Users/samgdf/Documents/observability-workshop --buildDrafts --buildFuture --minify --destination /tmp/observability-workshop-pr-build`
- staged diff whitespace check

## Notes
- the workshop is intentionally marked `draft: true` and `hidden: true`

[Warp conversation](https://app.warp.dev/conversation/34b6d37a-b577-483c-a291-6867c946741d)

Co-Authored-By: Oz <oz-agent@warp.dev>