### PR TITLE
chore: bump theme and add OTel version parameters

### DIFF
--- a/content/en/conf/1-advanced-collector/prerequisites.md
+++ b/content/en/conf/1-advanced-collector/prerequisites.md
@@ -44,7 +44,7 @@ kubectl delete ~/workshop/apm/deployment.yaml
 {{% tab title="Splunk Workshop Instance" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_linux_amd64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_linux_amd64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-linux-amd64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh
@@ -54,7 +54,7 @@ chmod +x setup-workshop.sh
 {{% tab title="Apple Silicon" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-darwin-arm64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh

--- a/content/en/ninja-workshops/ai/1-agentic-ai/3-deploy-collector.md
+++ b/content/en/ninja-workshops/ai/1-agentic-ai/3-deploy-collector.md
@@ -62,7 +62,7 @@ Now we can use the following command to install the collector:
 {{% tab title="Script" %}}
 
 ``` bash
-  helm upgrade --install splunk-otel-collector --version {{< otel-version >}} \
+  helm upgrade --install splunk-otel-collector --version {{< legacy-otel-version >}} \
   --set="splunkObservability.realm=$REALM" \
   --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
   --set="clusterName=$INSTANCE-cluster" \

--- a/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/2-preparation/1-otel.md
+++ b/content/en/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/2-preparation/1-otel.md
@@ -44,7 +44,7 @@ To install the collector run the following command. Do **NOT** edit this:
 {{% tab title="Helm Install" %}}
 
 ```bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="operatorcrds.install=true", \
 --set="operator.enabled=true", \
 --set="splunkObservability.realm=$REALM" \

--- a/content/en/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector-old/prerequisites.md
+++ b/content/en/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector-old/prerequisites.md
@@ -22,7 +22,7 @@ time: 90 minutes
 {{% tab title="Splunk Workshop Instance" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_linux_amd64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_linux_amd64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-linux-amd64 -o loadgen
 ```
 
@@ -38,7 +38,7 @@ chmod +x otelcol loadgen && \
 {{% tab title="Apple Silicon" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-darwin-arm64 -o loadgen
 ```
 

--- a/content/en/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
+++ b/content/en/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
@@ -49,7 +49,7 @@ Change into your `[WORKSHOP]` directory and download the OpenTelemetry Collector
 {{% tab title="Splunk Workshop Instance" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_linux_amd64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_linux_amd64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-linux-amd64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh
@@ -59,7 +59,7 @@ chmod +x setup-workshop.sh
 {{% tab title="Apple Silicon" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-darwin-arm64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh

--- a/content/en/ninja-workshops/infrastructure/1-hpa/1-deploy-otel.md
+++ b/content/en/ninja-workshops/infrastructure/1-hpa/1-deploy-otel.md
@@ -46,7 +46,7 @@ Install the OpenTelemetry Collector Helm with the following commands, do **NOT**
 {{% tab title="helm install" %}}
 
 ``` bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \

--- a/content/en/unsupported-field-workshops/1-imt/gdi/_index.md
+++ b/content/en/unsupported-field-workshops/1-imt/gdi/_index.md
@@ -40,7 +40,7 @@ Install the OpenTelemetry Collector Helm chart with the following commands, do *
 {{% tab title="Helm Install" %}}
 
 ```bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \
@@ -56,7 +56,7 @@ splunk-otel-collector-chart/splunk-otel-collector \
 ```
 <!--
 ``` bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \

--- a/content/en/unsupported-field-workshops/3-nodejs-kubernetes/2-otel-collector.md
+++ b/content/en/unsupported-field-workshops/3-nodejs-kubernetes/2-otel-collector.md
@@ -48,7 +48,7 @@ helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel
 ```
 
 ``` bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="operatorcrds.install=true", \
 --set="operator.enabled=true", \
 --set="splunkObservability.realm=$REALM" \

--- a/content/ja/ninja-workshops/ai/1-agentic-ai/3-deploy-collector.md
+++ b/content/ja/ninja-workshops/ai/1-agentic-ai/3-deploy-collector.md
@@ -52,7 +52,7 @@ agent:
 {{% tab title="Script" %}}
 
 ``` bash
-  helm upgrade --install splunk-otel-collector --version {{< otel-version >}} \
+  helm upgrade --install splunk-otel-collector --version {{< legacy-otel-version >}} \
   --set="splunkObservability.realm=$REALM" \
   --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
   --set="clusterName=$INSTANCE-cluster" \

--- a/content/ja/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/2-preparation/1-otel.md
+++ b/content/ja/ninja-workshops/foundations/1-automatic-discovery/2-petclinic-kubernetes/2-preparation/1-otel.md
@@ -44,7 +44,7 @@ Collectorをインストールするには、以下のコマンドを実行し�
 {{% tab title="Helm Install" %}}
 
 ```bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="operatorcrds.install=true", \
 --set="operator.enabled=true", \
 --set="splunkObservability.realm=$REALM" \

--- a/content/ja/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
+++ b/content/ja/ninja-workshops/foundations/2-opentelemetry-collector-workshops/2-advanced-collector/prerequisites.md
@@ -44,7 +44,7 @@ kubectl delete ~/workshop/apm/deployment.yaml
 {{% tab title="Splunk Workshop Instance" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_linux_amd64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_linux_amd64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-linux-amd64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh
@@ -54,7 +54,7 @@ chmod +x setup-workshop.sh
 {{% tab title="Apple Silicon" %}}
 
 ```bash
-curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
+curl -L https://github.com/signalfx/splunk-otel-collector/releases/download/v{{< legacy-otel-version >}}/otelcol_darwin_arm64 -o otelcol && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/loadgen/build/loadgen-darwin-arm64 -o loadgen && \
 curl -L https://github.com/splunk/observability-workshop/raw/refs/heads/main/workshop/ninja/advanced-otel/setup-workshop.sh -o setup-workshop.sh && \
 chmod +x setup-workshop.sh

--- a/content/ja/ninja-workshops/infrastructure/1-hpa/1-deploy-otel.md
+++ b/content/ja/ninja-workshops/infrastructure/1-hpa/1-deploy-otel.md
@@ -46,7 +46,7 @@ Update Complete. ⎈Happy Helming!⎈
 {{% tab title="helm install" %}}
 
 ``` bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \

--- a/content/ja/unsupported-field-workshops/1-imt/gdi/_index.md
+++ b/content/ja/unsupported-field-workshops/1-imt/gdi/_index.md
@@ -40,7 +40,7 @@ Update Complete. ⎈Happy Helming!⎈
 {{% tab title="Helm Install" %}}
 
 ```bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \
@@ -56,7 +56,7 @@ splunk-otel-collector-chart/splunk-otel-collector \
 ```
 <!--
 ``` bash
-helm install splunk-otel-collector --version {{< otel-version >}} \
+helm install splunk-otel-collector --version {{< legacy-otel-version >}} \
 --set="splunkObservability.realm=$REALM" \
 --set="splunkObservability.accessToken=$ACCESS_TOKEN" \
 --set="clusterName=$INSTANCE-k3s-cluster" \

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.13 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.14 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.13.13 h1:adfwT32zsJWS8fc2Yb7ECVS1Bd8OYizZG2OdnbDYwwE=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.13/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.14 h1:gXYi5G55Qex3QyuvbX2RfzUMSqnd5rbeefZkwlJiEKo=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.14/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=

--- a/hugo.toml
+++ b/hugo.toml
@@ -160,7 +160,9 @@ disableKinds = ["taxonomy", "term"]
   # omit the badge entirely.
   versionBadgeRepo  = "splunk/observability-workshop"
   versionBadgeColor = "FF007F"   # hex without the leading #
-  stableOtelVersion = "0.136.0"
+  stableOtelVersion = "0.136.0"  # remains for backward compatibility
+  legacyOtelVersion = "0.136.0"  # new legacy version for Splunk Show and existing workshops
+  latestOtelVersion = "0.158.0"  # new latest version for Splunk Show and Astronomy Shop (Rookies)
 
   [params.social]
     github   = "https://github.com/splunk/observability-workshop"


### PR DESCRIPTION
Upgrade the workshop theme to v0.13.14 and define separate legacy and latest OpenTelemetry Collector versions while retaining the stable parameter for compatibility.

Update existing workshop content to use the legacy collector version shortcode.

