### PR TITLE
fix: load workshop RUM only on GitHub Pages

### DIFF
--- a/layouts/_partials/custom-header.html
+++ b/layouts/_partials/custom-header.html
@@ -9,6 +9,8 @@
 </style>
 {{- end }}
 
+{{/* Only instrument GitHub Pages builds; never load RUM in hugo server. */}}
+{{- if and (not hugo.IsServer) (strings.HasSuffix (urls.Parse .Site.BaseURL).Host ".github.io") }}
 <script src="https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3/splunk-otel-web.js" crossorigin="anonymous"></script>
 <script src="https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3/splunk-otel-web-session-recorder.js" crossorigin="anonymous"></script>
 <script>
@@ -30,3 +32,4 @@ SplunkSessionRecorder.init({
     }
 });
 </script>
+{{- end }}


### PR DESCRIPTION
Skip the collector scripts during local hugo server so development traffic is not sent to the production RUM application.
