### PR TITLE
chore: bump Hugo theme to v0.13.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/splunk/observability-workshops
 
 go 1.26.3
 
-require github.com/splunk/hugo-theme-splunk-workshop v0.13.14 // indirect
+require github.com/splunk/hugo-theme-splunk-workshop v0.13.17 // indirect
 
 //replace github.com/splunk/hugo-theme-splunk-workshop => /Users/rcastley/Documents/GitHub/hugo-theme-splunk-workshop

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/splunk/hugo-theme-splunk-workshop v0.13.14 h1:gXYi5G55Qex3QyuvbX2RfzUMSqnd5rbeefZkwlJiEKo=
-github.com/splunk/hugo-theme-splunk-workshop v0.13.14/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.17 h1:kUXIzfNAy70JW3tOlXEEEGZ17ELAfqrt+zTke1Z39B4=
+github.com/splunk/hugo-theme-splunk-workshop v0.13.17/go.mod h1:W41sA3uf5oTWqIUA1aUY4M0C/JEaMa0gV3CqVDs0ReA=


### PR DESCRIPTION
Pick up the card footer alignment and new path-selection icons used by the Rookies workshop landing.
