### PR TITLE
docs: add Rookies path selection and module browse

### DIFF
--- a/content/en/splunk4rookies/o11y-rookies-26/1-modules/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/1-modules/_index.md
@@ -1,10 +1,10 @@
 ---
 
 title: Workshop Modules
-linkTitle: 1. Lessons
+linkTitle: Modules
 menuPost: " <i class='fa fa-graduation-cap'></i>"
 layout: hero
 weight: 1
-description: Select the modules your instructor has chosen for today's session.
+description: Browse every workshop module and select the ones you want to complete.
 ---
 {{% children depth="1" type="card" description="true" image="true" showhidden="true" %}}

--- a/content/en/splunk4rookies/o11y-rookies-26/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/_index.md
@@ -26,9 +26,18 @@ If you’re new to *Splunk Observability Cloud*, begin with the **Intro** lesson
 After completing the Intro, you can take the remaining lessons in any order. Each lesson is self-contained and focuses on a specific concept or challenge.
 Your instructor may recommend a particular learning path based on the goal of your session.
 
-## Lessons
+{{< button href="/splunk4rookies/o11y-rookies-26/1-modules/1-intro/" style="primary" icon="play" >}}Start the Introduction Workshop{{< /button >}}
 
-{{% children page="1-modules" depth="1" type="card" description="true" image="true" showhidden="true" %}}
+## Continue your workshop
+
+{{< cards >}}
+{{< card title="Choose Your Path" href="/splunk4rookies/o11y-rookies-26/choose-your-path/" hero-icon="route" >}}
+Follow a recommended route through the modules based on your area of interest.
+{{< /card >}}
+{{< card title="Browse All Modules" href="/splunk4rookies/o11y-rookies-26/1-modules/" hero-icon="library" >}}
+View every available workshop module and choose the ones you want to complete.
+{{< /card >}}
+{{< /cards >}}
 
 {{% notice style="note" title="Parking Lot" icon="circle-info" %}}
 Login instructions and Astronomy Shop setup details are available at the end of the workshop navigation for reference.

--- a/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/_index.md
@@ -1,0 +1,21 @@
+---
+title: Choose Your Path
+linkTitle: Choose Your Path
+layout: hero
+weight: 1
+description: Select a recommended route through the workshop based on the observability skills you want to develop.
+---
+
+Each path starts with the introduction and then guides you through the modules most relevant to your area of interest.
+
+{{< cards >}}
+{{< card title="Infrastructure Monitoring" href="/splunk4rookies/o11y-rookies-26/choose-your-path/infrastructure-monitoring/" hero-icon="server" >}}
+Investigate infrastructure, logs, and databases to understand the health of the systems supporting your applications.
+{{< /card >}}
+{{< card title="Digital Experience Monitoring" href="/splunk4rookies/o11y-rookies-26/choose-your-path/digital-experience-monitoring/" hero-icon="monitor-smartphone" >}}
+Understand real user experiences, proactively test critical journeys, and analyse customer behaviour.
+{{< /card >}}
+{{< card title="AI Monitoring" href="/splunk4rookies/o11y-rookies-26/choose-your-path/ai-monitoring/" hero-icon="sparkles" >}}
+Use AI-assisted workflows and application telemetry to accelerate investigation and troubleshooting.
+{{< /card >}}
+{{< /cards >}}

--- a/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/ai-monitoring/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/ai-monitoring/_index.md
@@ -1,0 +1,21 @@
+---
+title: AI Monitoring Path
+linkTitle: AI Monitoring
+layout: hero
+weight: 3
+description: Follow the AI path to use AI-assisted workflows and application telemetry to investigate problems faster.
+---
+
+Complete these modules in the recommended order:
+
+{{< cards >}}
+{{< card title="Introduction to Observability Cloud" href="/splunk4rookies/o11y-rookies-26/1-modules/1-intro/" show-time="true" >}}
+Learn the foundations of Splunk Observability Cloud using the fully instrumented Astronomy Shop.
+{{< /card >}}
+{{< card title="Let's Introduce Our Friend" href="/splunk4rookies/o11y-rookies-26/1-modules/2-ai/" show-time="true" >}}
+Use Splunk AI capabilities to reduce noise, surface likely causes, and accelerate investigations.
+{{< /card >}}
+{{< card title="Where Did That Error Come From?" href="/splunk4rookies/o11y-rookies-26/1-modules/3-apm/" show-time="true" >}}
+Follow application traces across services to identify where an error originated.
+{{< /card >}}
+{{< /cards >}}

--- a/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/digital-experience-monitoring/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/digital-experience-monitoring/_index.md
@@ -1,0 +1,21 @@
+---
+title: Digital Experience Monitoring Path
+linkTitle: Digital Experience Monitoring
+layout: hero
+weight: 2
+description: Follow the digital experience path to understand real user behaviour and proactively monitor critical journeys.
+---
+
+Complete these modules in the recommended order:
+
+{{< cards >}}
+{{< card title="Introduction to Observability Cloud" href="/splunk4rookies/o11y-rookies-26/1-modules/1-intro/" show-time="true" >}}
+Learn the foundations of Splunk Observability Cloud using the fully instrumented Astronomy Shop.
+{{< /card >}}
+{{< card title="Find the Issue Before Social Media Does" href="/splunk4rookies/o11y-rookies-26/1-modules/5-dem/" show-time="true" >}}
+Combine Real User Monitoring and Synthetics to identify and prevent poor customer experiences.
+{{< /card >}}
+{{< card title="Digital Experience Analytics" href="/splunk4rookies/o11y-rookies-26/1-modules/9-dxa/" show-time="true" >}}
+Explore adoption, frustration, funnels, and user segments using Digital Experience Analytics.
+{{< /card >}}
+{{< /cards >}}

--- a/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/infrastructure-monitoring/_index.md
+++ b/content/en/splunk4rookies/o11y-rookies-26/choose-your-path/infrastructure-monitoring/_index.md
@@ -1,0 +1,24 @@
+---
+title: Infrastructure Monitoring Path
+linkTitle: Infrastructure Monitoring
+layout: hero
+weight: 1
+description: Follow the infrastructure path to investigate resources, logs, and databases supporting the Astronomy Shop.
+---
+
+Complete these modules in the recommended order:
+
+{{< cards >}}
+{{< card title="Introduction to Observability Cloud" href="/splunk4rookies/o11y-rookies-26/1-modules/1-intro/" show-time="true" >}}
+Learn the foundations of Splunk Observability Cloud using the fully instrumented Astronomy Shop.
+{{< /card >}}
+{{< card title="Neighbours Are a Pain" href="/splunk4rookies/o11y-rookies-26/1-modules/4-im/" show-time="true" >}}
+Find a noisy neighbour using Splunk Infrastructure Monitoring.
+{{< /card >}}
+{{< card title="Finding the Needle in the Logs" href="/splunk4rookies/o11y-rookies-26/1-modules/6-logs/" show-time="true" >}}
+Use Log Observer to identify patterns and determine the root cause of an incident.
+{{< /card >}}
+{{< card title="What Is That Database Doing?" href="/splunk4rookies/o11y-rookies-26/1-modules/7-db-mon/" show-time="true" >}}
+Investigate database performance and its impact on the application.
+{{< /card >}}
+{{< /cards >}}


### PR DESCRIPTION
Give instructors a landing flow with a direct Intro start, curated paths, and a full module list without changing the existing lesson content.
